### PR TITLE
Make isolated lambda Authorization header case-insensitive

### DIFF
--- a/isolated/uploaders.py
+++ b/isolated/uploaders.py
@@ -57,10 +57,12 @@ def get_upload_url(shortid):
 
 
 def get_auth_token(headers):
-	if "Authorization" not in headers:
+	lowercase_headers = {k.lower(): v for k, v in headers.items()}
+
+	if "authorization" not in lowercase_headers:
 		raise Exception("The Authorization Header is required.")
 
-	auth_components = headers["Authorization"].split()
+	auth_components = lowercase_headers["authorization"].split()
 	if len(auth_components) != 2:
 		raise Exception("Authorization header must have a scheme and a token.")
 


### PR DESCRIPTION
HTTP header keys are supposed to be case-insensitive in HTTP/1.X, and always lowercase in HTTP/2.0. This commit converts all incoming HTTP header keys to lowercase during processing. The lowercasing dict comprehension is Python 2.7 compatible from what I can tell, and as such I expect it to work on the lambdas.

The canary system should not let this pass if something breaks. Nontheless, can you please take a brief look at it?

Closes #128. From what I  can tell the rest of the API already works with lowercase header keys, I guess that Django's method of looking at headers respects casing as opposed to these direct lookups.