### PR TITLE
Switch to ICU formatting

### DIFF
--- a/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
+++ b/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
@@ -161,8 +161,8 @@ class CopyDeckButton extends React.Component<Props, State> {
 		return (
 			[
 				`### ${deckName}`,
-				"# " + t("Class: {{ className }}", { className }),
-				"# " + t("Format: {{ formatName }}", { formatName }),
+				"# " + t("Class: {className}", { className }),
+				"# " + t("Format: {formatName}", { formatName }),
 				standard ? "# " + t("Year of the Raven") : "",
 				"#",
 				...prettyDeckList,
@@ -172,7 +172,7 @@ class CopyDeckButton extends React.Component<Props, State> {
 					t(
 						"To use this deck, copy it to your clipboard and create a new deck in Hearthstone",
 					),
-				"# " + t("Find this deck on {{ deckUrl }}", { deckUrl }),
+				"# " + t("Find this deck on {deckUrl}", { deckUrl }),
 			]
 				.filter(Boolean)
 				.join("\n") + "\n"

--- a/hsreplaynet/static/scripts/src/components/collection/modal/CollectionSetupDialog.tsx
+++ b/hsreplaynet/static/scripts/src/components/collection/modal/CollectionSetupDialog.tsx
@@ -455,7 +455,7 @@ class CollectionSetupDialog extends React.Component<Props, State> {
 								id="collection-setup-progress-step"
 								className="sr-only"
 							>
-								{t("Step {{step}} of {{lastStep}}", {
+								{t("Step {step} of {lastStep}", {
 									step: this.state.step,
 									lastStep: LAST_STEP,
 								})}

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
@@ -73,7 +73,7 @@ class DeckOverviewTable extends React.Component<Props> {
 						<td>{t("Match duration")}</td>
 						<td>
 							{deck &&
-								t("{{durationInMinutes}} minutes", {
+								t("{durationInMinutes} minutes", {
 									durationInMinutes: (
 										deck.avg_game_length_seconds / 60
 									).toFixed(1),

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckStats.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckStats.tsx
@@ -42,7 +42,7 @@ class DeckStats extends React.Component<Props, State> {
 					<li>
 						{t("Sample size")}
 						<span className="infobox-value">
-							{t("{{totalGames}} games", { totalGames })}
+							{t("{totalGames} games", { totalGames })}
 						</span>
 					</li>
 					<li>

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckStats.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckStats.tsx
@@ -3,6 +3,8 @@ import { InjectedTranslateProps, translate } from "react-i18next";
 import { toPrettyNumber } from "../../helpers";
 import { TableData } from "../../interfaces";
 import InfoboxLastUpdated from "../InfoboxLastUpdated";
+import { TimeRange } from "../../filters";
+import PrettyTimeRange from "../text/PrettyTimeRange";
 
 interface Props extends InjectedTranslateProps {
 	data?: TableData;
@@ -46,7 +48,9 @@ class DeckStats extends React.Component<Props, State> {
 					<li>
 						{t("Time frame")}
 						<span className="infobox-value">
-							{t("Last {{n}} days", { n: 30 })}
+							<PrettyTimeRange
+								timeRange={TimeRange.LAST_30_DAYS}
+							/>
 						</span>
 					</li>
 					<InfoboxLastUpdated

--- a/hsreplaynet/static/scripts/src/components/home/ArchetypeHighlight.tsx
+++ b/hsreplaynet/static/scripts/src/components/home/ArchetypeHighlight.tsx
@@ -107,7 +107,7 @@ class ArchetypeHighlight extends React.Component<Props, State> {
 		const ranks = [];
 		ranks.push(t("Legend"));
 		for (let i = 1; i <= 25; i++) {
-			ranks.push(t("Rank {{rank}}", { rank: i }));
+			ranks.push(t("Rank {rank}", { rank: i }));
 		}
 		return ranks;
 	}
@@ -141,7 +141,7 @@ class ArchetypeHighlight extends React.Component<Props, State> {
 					<h2>{archetype.name}</h2>
 					<p>
 						<span>
-							{t("Winrate: {{winrate}}", {
+							{t("Winrate: {winrate}", {
 								winrate:
 									toDynamicFixed(result.win_rate, 1) + "%",
 							})}

--- a/hsreplaynet/static/scripts/src/components/rankpicker/RankSelector.tsx
+++ b/hsreplaynet/static/scripts/src/components/rankpicker/RankSelector.tsx
@@ -17,7 +17,7 @@ class RankSelector extends React.Component<Props> {
 		const classNames = ["rank-selector"].concat(this.props.classNames);
 		const srcString = rank === 0 ? "Legend" : rank;
 		const rankStr = rank === 0 ? t("Legend") : rank;
-		const altStr = rank === 0 ? t("Legend") : t("Rank {{rank}}", { rank });
+		const altStr = rank === 0 ? t("Legend") : t("Rank {rank}", { rank });
 		return (
 			<button
 				className={classNames.join(" ")}

--- a/hsreplaynet/static/scripts/src/components/text/PrettyRankRange.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyRankRange.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { InjectedTranslateProps, translate } from "react-i18next";
+import { RankRange } from "../../filters";
+
+interface Props extends InjectedTranslateProps {
+	rankRange: keyof typeof RankRange;
+}
+
+class PrettyRankRange extends React.Component<Props> {
+	private renderRank(rank: string): string {
+		const { t } = this.props;
+
+		switch (rank) {
+			case "LEGEND":
+				return t("Legend");
+			case "ONE":
+				return "1";
+			case "FIVE":
+				return "5";
+			case "TEN":
+				return "10";
+			case "FIFTEEN":
+				return "15";
+			case "TWENTY":
+				return "20";
+			case "TWENTYFIVE":
+				return "25";
+		}
+
+		return rank;
+	}
+
+	private renderRankRange(minRank: string, maxRank: string): string {
+		const { t } = this.props;
+		return t("{{rankMin}}–{{rankMax}}", {
+			rankMin: minRank,
+			rankMax: maxRank,
+		});
+	}
+
+	public render(): React.ReactNode {
+		const { rankRange, t } = this.props;
+
+		const matches = /^([A-Z]+)_THROUGH_([A-Z]+)$/.exec(
+			rankRange.toUpperCase(),
+		);
+		if (matches !== null) {
+			const rankMin = this.renderRank(matches[1]);
+			const rankMax = this.renderRank(matches[2]);
+			return this.renderRankRange(rankMin, rankMax);
+		}
+
+		switch (rankRange) {
+			case RankRange.LEGEND_ONLY:
+				return t("Legend only");
+			case RankRange.ALL:
+				return this.renderRankRange(
+					this.renderRank("LEGEND"),
+					this.renderRank("TWENTYFIVE"),
+				);
+		}
+
+		return rankRange;
+	}
+}
+
+export default translate()(PrettyRankRange);

--- a/hsreplaynet/static/scripts/src/components/text/PrettyRankRange.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyRankRange.tsx
@@ -32,7 +32,7 @@ class PrettyRankRange extends React.Component<Props> {
 
 	private renderRankRange(minRank: string, maxRank: string): string {
 		const { t } = this.props;
-		return t("{{rankMin}}–{{rankMax}}", {
+		return t("{rankMin}–{rankMax}", {
 			rankMin: minRank,
 			rankMax: maxRank,
 		});

--- a/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { InjectedTranslateProps, translate } from "react-i18next";
+import { TimeRange } from "../../filters";
+
+interface Props extends InjectedTranslateProps {
+	timeRange: keyof typeof TimeRange;
+}
+
+class PrettyTimeRange extends React.Component<Props> {
+	public render(): React.ReactNode {
+		const { timeRange, t } = this.props;
+
+		const matches = /^LAST_(\d+)_DAYS?$/.exec("" + timeRange);
+		if (matches !== null) {
+			return t("Last {{n}} days", {
+				n: +matches[1],
+			});
+		}
+
+		switch (timeRange) {
+			case TimeRange.CURRENT_SEASON:
+				return t("Current season");
+			case TimeRange.PREVIOUS_SEASON:
+				return t("Previous season");
+			case TimeRange.CURRENT_EXPANSION:
+				return t("Latest expansion");
+			case TimeRange.CURRENT_PATCH:
+				return t("Latest patch");
+		}
+
+		return timeRange;
+	}
+}
+
+export default translate()(PrettyTimeRange);

--- a/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
@@ -12,7 +12,7 @@ class PrettyTimeRange extends React.Component<Props> {
 
 		const matches = /^LAST_(\d+)_DAYS?$/.exec("" + timeRange);
 		if (matches !== null) {
-			return t("Last {{n}} days", {
+			return t("Last {n} days", {
 				n: +matches[1],
 			});
 		}

--- a/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyTimeRange.tsx
@@ -12,7 +12,7 @@ class PrettyTimeRange extends React.Component<Props> {
 
 		const matches = /^LAST_(\d+)_DAYS?$/.exec("" + timeRange);
 		if (matches !== null) {
-			return t("Last {n} days", {
+			return t("Last {n, plural, one {# day} other {# days}}", {
 				n: +matches[1],
 			});
 		}

--- a/hsreplaynet/static/scripts/src/i18n.ts
+++ b/hsreplaynet/static/scripts/src/i18n.ts
@@ -1,6 +1,18 @@
 import i18n, { InitOptions } from "i18next";
 import CustomCallbackBackend from "i18next-callback-backend";
 import ICU from "i18next-icu";
+import de from "i18next-icu/locale-data/de";
+import en from "i18next-icu/locale-data/en";
+import es from "i18next-icu/locale-data/es";
+import fr from "i18next-icu/locale-data/fr";
+import it from "i18next-icu/locale-data/it";
+import ja from "i18next-icu/locale-data/ja";
+import ko from "i18next-icu/locale-data/ko";
+import pl from "i18next-icu/locale-data/pl";
+import pt from "i18next-icu/locale-data/pt";
+import ru from "i18next-icu/locale-data/ru";
+import th from "i18next-icu/locale-data/th";
+import zh from "i18next-icu/locale-data/zh";
 import UserData from "./UserData";
 
 export const I18N_NAMESPACE_FRONTEND = "frontend";
@@ -20,6 +32,14 @@ i18n
 		keySeparator: false,
 		lowerCaseLng: true,
 		nsSeparator: false,
+
+		// i18next-icu
+		i18nFormat: {
+			/* We cannot load these dynamically right now due to the different
+			file names. There's not a lot data behind these though, so we just
+			hardcode the languages we support for now. */
+			localeData: [de, en, es, fr, it, ja, ko, pl, pt, ru, th, zh],
+		},
 
 		// not required using i18next-react
 		interpolation: {

--- a/hsreplaynet/static/scripts/src/pages/ArchetypeDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/ArchetypeDetail.tsx
@@ -33,6 +33,7 @@ import {
 	RankRange as RankRangeFilter,
 	TimeRange as TimeRangeFilter,
 } from "../filters";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface Props extends InjectedTranslateProps {
 	archetypeId: number;
@@ -636,7 +637,9 @@ class ArchetypeDetail extends React.Component<Props, State> {
 							<li>
 								{t("Time frame")}
 								<span className="infobox-value">
-									{t("Last {{n}} days", { n: 7 })}
+									<PrettyTimeRange
+										timeRange={TimeRangeFilter.LAST_7_DAYS}
+									/>
 								</span>
 							</li>
 						</ul>

--- a/hsreplaynet/static/scripts/src/pages/ArchetypeDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/ArchetypeDetail.tsx
@@ -34,6 +34,7 @@ import {
 	TimeRange as TimeRangeFilter,
 } from "../filters";
 import PrettyTimeRange from "../components/text/PrettyTimeRange";
+import PrettyRankRange from "../components/text/PrettyRankRange";
 
 interface Props extends InjectedTranslateProps {
 	archetypeId: number;
@@ -596,32 +597,37 @@ class ArchetypeDetail extends React.Component<Props, State> {
 								<InfoboxFilter
 									value={RankRangeFilter.LEGEND_ONLY}
 								>
-									{t("Legend only")}
+									<PrettyRankRange
+										rankRange={RankRangeFilter.LEGEND_ONLY}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter
 									value={RankRangeFilter.LEGEND_THROUGH_FIVE}
 								>
-									{t("{{rankMin}}–{{rankMax}}", {
-										rankMin: t("Legend"),
-										rankMax: 5,
-									})}
+									<PrettyRankRange
+										rankRange={
+											RankRangeFilter.LEGEND_THROUGH_FIVE
+										}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter
 									value={RankRangeFilter.LEGEND_THROUGH_TEN}
 								>
-									{t("{{rankMin}}–{{rankMax}}", {
-										rankMin: t("Legend"),
-										rankMax: 10,
-									})}
+									<PrettyRankRange
+										rankRange={
+											RankRangeFilter.LEGEND_THROUGH_TEN
+										}
+									/>
 								</InfoboxFilter>
 							</PremiumWrapper>
 							<InfoboxFilter
 								value={RankRangeFilter.LEGEND_THROUGH_TWENTY}
 							>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 20,
-								})}
+								<PrettyRankRange
+									rankRange={
+										RankRangeFilter.LEGEND_THROUGH_TWENTY
+									}
+								/>
 							</InfoboxFilter>
 						</InfoboxFilterGroup>
 					</section>

--- a/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
@@ -349,7 +349,7 @@ class CardDetail extends React.Component<Props, State> {
 				content = [
 					<section id="content-header" key="content-header">
 						<h1>
-							{t("{{ cardName }} – Statistics", {
+							{t("{cardName} – Statistics", {
 								cardName: this.props.card.name,
 							})}
 						</h1>
@@ -601,7 +601,7 @@ class CardDetail extends React.Component<Props, State> {
 				{this.props.card ? (
 					<span className="infobox-value">
 						{dustCost > 0
-							? t("{{dustCost}} Dust", { dustCost })
+							? t("{dustCost} Dust", { dustCost })
 							: t("Not craftable")}
 					</span>
 				) : null}
@@ -710,7 +710,7 @@ class CardDetail extends React.Component<Props, State> {
 											const numReplays = toPrettyNumber(
 												series.metadata.num_data_points,
 											);
-											return t("{{numReplays}} replays", {
+											return t("{numReplays} replays", {
 												numReplays,
 											});
 										}

--- a/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
@@ -39,6 +39,7 @@ import { I18N_NAMESPACE_HEARTHSTONE } from "../i18n";
 import { RenderData, TableData } from "../interfaces";
 import { Collection } from "../utils/api";
 import PrettyTimeRange from "../components/text/PrettyTimeRange";
+import PrettyRankRange from "../components/text/PrettyRankRange";
 
 interface Props extends InjectedTranslateProps {
 	card: any;
@@ -666,28 +667,25 @@ class CardDetail extends React.Component<Props, State> {
 							iconStyle={{ display: "none" }}
 						>
 							<InfoboxFilter value={RankRange.LEGEND_ONLY}>
-								{t("Legend only")}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_ONLY}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter
 								value={RankRange.LEGEND_THROUGH_FIVE}
 							>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 5,
-								})}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_THROUGH_FIVE}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter value={RankRange.LEGEND_THROUGH_TEN}>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 10,
-								})}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_THROUGH_TEN}
+								/>
 							</InfoboxFilter>
 						</PremiumWrapper>
 						<InfoboxFilter value={RankRange.ALL}>
-							{t("{{rankMin}}–{{rankMax}}", {
-								rankMin: t("Legend"),
-								rankMax: 25,
-							})}
+							<PrettyRankRange rankRange={RankRange.ALL} />
 						</InfoboxFilter>
 					</InfoboxFilterGroup>
 					<h2>{t("Data")}</h2>

--- a/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
@@ -27,7 +27,7 @@ import HideLoading from "../components/loading/HideLoading";
 import TableLoading from "../components/loading/TableLoading";
 import PremiumWrapper from "../components/premium/PremiumWrapper";
 import PrettyCardClass from "../components/text/PrettyCardClass";
-import { RankRange } from "../filters";
+import { RankRange, TimeRange } from "../filters";
 import {
 	getChartScheme,
 	getDustCost,
@@ -38,6 +38,7 @@ import {
 import { I18N_NAMESPACE_HEARTHSTONE } from "../i18n";
 import { RenderData, TableData } from "../interfaces";
 import { Collection } from "../utils/api";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface Props extends InjectedTranslateProps {
 	card: any;
@@ -727,7 +728,9 @@ class CardDetail extends React.Component<Props, State> {
 						<li>
 							{t("Time frame")}
 							<span className="infobox-value">
-								{t("Last {{n}} days", { n: 30 })}
+								<PrettyTimeRange
+									timeRange={TimeRange.LAST_30_DAYS}
+								/>
 							</span>
 						</li>
 						<InfoboxLastUpdated

--- a/hsreplaynet/static/scripts/src/pages/Cards.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Cards.tsx
@@ -1,5 +1,5 @@
+import InfoboxLastUpdated from "../components/InfoboxLastUpdated";
 import _ from "lodash";
-import React, { Fragment } from "react";
 import { InjectedTranslateProps, translate } from "react-i18next";
 import CardData from "../CardData";
 import DataManager from "../DataManager";
@@ -10,7 +10,7 @@ import DataInjector from "../components/DataInjector";
 import Feature from "../components/Feature";
 import InfoboxFilter from "../components/InfoboxFilter";
 import InfoboxFilterGroup from "../components/InfoboxFilterGroup";
-import InfoboxLastUpdated from "../components/InfoboxLastUpdated";
+import React, { Fragment } from "react";
 import ResetHeader from "../components/ResetHeader";
 import TableLoading from "../components/loading/TableLoading";
 import PremiumWrapper from "../components/premium/PremiumWrapper";
@@ -38,6 +38,7 @@ import {
 } from "../utils/collection";
 import { RankRange, TimeRange } from "../filters";
 import PrettyTimeRange from "../components/text/PrettyTimeRange";
+import PrettyRankRange from "../components/text/PrettyRankRange";
 
 interface CardFilters {
 	cost: any;
@@ -1091,28 +1092,25 @@ class Cards extends React.Component<Props, State> {
 							iconStyle={{ display: "none" }}
 						>
 							<InfoboxFilter value={RankRange.LEGEND_ONLY}>
-								{t("Legend only")}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_ONLY}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter
 								value={RankRange.LEGEND_THROUGH_FIVE}
 							>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 5,
-								})}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_THROUGH_FIVE}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter value={RankRange.LEGEND_THROUGH_TEN}>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 10,
-								})}
+								<PrettyRankRange
+									rankRange={RankRange.LEGEND_THROUGH_TEN}
+								/>
 							</InfoboxFilter>
 						</PremiumWrapper>
 						<InfoboxFilter value={RankRange.ALL}>
-							{t("{{rankMin}}–{{rankMax}}", {
-								rankMin: t("Legend"),
-								rankMax: 20,
-							})}
+							<PrettyRankRange rankRange={RankRange.ALL} />
 						</InfoboxFilter>
 					</InfoboxFilterGroup>
 				</Fragment>,

--- a/hsreplaynet/static/scripts/src/pages/Cards.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Cards.tsx
@@ -37,6 +37,7 @@ import {
 	isCollectionDisabled,
 } from "../utils/collection";
 import { RankRange, TimeRange } from "../filters";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface CardFilters {
 	cost: any;
@@ -1028,23 +1029,33 @@ class Cards extends React.Component<Props, State> {
 								iconStyle={{ display: "none" }}
 							>
 								<InfoboxFilter value={TimeRange.LAST_1_DAY}>
-									{t("Last 1 day")}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_1_DAY}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter value={TimeRange.LAST_3_DAYS}>
-									{t("Last {{n}} days", { n: 3 })}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_3_DAYS}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter value={TimeRange.LAST_7_DAYS}>
-									{t("Last {{n}} days", { n: 7 })}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_7_DAYS}
+									/>
 								</InfoboxFilter>
 							</PremiumWrapper>
 							<InfoboxFilter value={TimeRange.LAST_14_DAYS}>
-								{t("Last {{n}} days", { n: 14 })}
+								<PrettyTimeRange
+									timeRange={TimeRange.LAST_14_DAYS}
+								/>
 							</InfoboxFilter>
 							<Feature feature={"current-expansion-filter"}>
 								<InfoboxFilter
 									value={TimeRange.CURRENT_EXPANSION}
 								>
-									{t("The Witchwood")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_EXPANSION}
+									/>
 									<span className="infobox-value">
 										{t("New!")}
 									</span>
@@ -1052,7 +1063,12 @@ class Cards extends React.Component<Props, State> {
 							</Feature>
 							<Feature feature={"current-patch-filter"}>
 								<InfoboxFilter value={TimeRange.CURRENT_PATCH}>
-									{t("Latest patch")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_PATCH}
+									/>
+									<span className="infobox-value">
+										{t("New!")}
+									</span>
 								</InfoboxFilter>
 							</Feature>
 						</InfoboxFilterGroup>
@@ -1113,26 +1129,30 @@ class Cards extends React.Component<Props, State> {
 					key="timeframe"
 				>
 					<InfoboxFilter value={TimeRange.LAST_3_DAYS}>
-						{t("Last {{n}} days", { n: 3 })}
+						<PrettyTimeRange timeRange={TimeRange.LAST_3_DAYS} />
 					</InfoboxFilter>
 					<InfoboxFilter value={TimeRange.LAST_7_DAYS}>
-						{t("Last {{n}} days", { n: 7 })}
+						<PrettyTimeRange timeRange={TimeRange.LAST_7_DAYS} />
 					</InfoboxFilter>
 					<InfoboxFilter value={TimeRange.LAST_30_DAYS}>
-						{t("Last {{n}} days", { n: 30 })}
+						<PrettyTimeRange timeRange={TimeRange.LAST_30_DAYS} />
 					</InfoboxFilter>
 					<InfoboxFilter value={TimeRange.CURRENT_SEASON}>
-						{t("Current season")}
+						<PrettyTimeRange timeRange={TimeRange.CURRENT_SEASON} />
 					</InfoboxFilter>
 					<Feature feature={"current-expansion-filter"}>
 						<InfoboxFilter value={TimeRange.CURRENT_EXPANSION}>
-							The Witchwood
+							<PrettyTimeRange
+								timeRange={TimeRange.CURRENT_EXPANSION}
+							/>
 							<span className="infobox-value">New!</span>
 						</InfoboxFilter>
 					</Feature>
 					<Feature feature={"current-patch-filter"}>
 						<InfoboxFilter value={TimeRange.CURRENT_PATCH}>
-							{t("Latest patch")}
+							<PrettyTimeRange
+								timeRange={TimeRange.CURRENT_PATCH}
+							/>
 							<span className="infobox-value">{t("New!")}</span>
 						</InfoboxFilter>
 					</Feature>

--- a/hsreplaynet/static/scripts/src/pages/DeckDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/DeckDetail.tsx
@@ -222,7 +222,7 @@ class DeckDetail extends React.Component<Props, State> {
 					<Tooltip
 						header={t("Not enough data")}
 						content={t(
-							"This deck does not have enough data at {{text}}.",
+							"This deck does not have enough data at {text}.",
 							{ text },
 						)}
 					>
@@ -366,7 +366,7 @@ class DeckDetail extends React.Component<Props, State> {
 							{infoBoxFilter(
 								"rankRange",
 								RankRange.LEGEND_THROUGH_FIVE,
-								t("{{rankMin}}–{{rankMax}}", {
+								t("{rankMin}–{rankMax}", {
 									rankMin: t("Legend"),
 									rankMax: 5,
 								}),
@@ -374,7 +374,7 @@ class DeckDetail extends React.Component<Props, State> {
 							{infoBoxFilter(
 								"rankRange",
 								RankRange.LEGEND_THROUGH_TEN,
-								t("{{rankMin}}–{{rankMax}}", {
+								t("{rankMin}–{rankMax}", {
 									rankMin: t("Legend"),
 									rankMax: 10,
 								}),
@@ -383,7 +383,7 @@ class DeckDetail extends React.Component<Props, State> {
 						{infoBoxFilter(
 							"rankRange",
 							"ALL",
-							t("{{rankMin}}–{{rankMax}}", {
+							t("{rankMin}–{rankMax}", {
 								rankMin: t("Legend"),
 								rankMax: 25,
 							}),
@@ -622,7 +622,7 @@ class DeckDetail extends React.Component<Props, State> {
 							{t("Cost")}
 							<span className="infobox-value">
 								{dustCost !== null
-									? t("{{dustCost}} Dust", { dustCost })
+									? t("{dustCost} Dust", { dustCost })
 									: t("Counting…")}
 							</span>
 						</li>

--- a/hsreplaynet/static/scripts/src/pages/Decks.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Decks.tsx
@@ -500,8 +500,8 @@ class Decks extends React.Component<Props, State> {
 			const helpMessage =
 				// prettier-ignore
 				<Trans>
-					Showing {{deckTypes}} with at least 10 unique pilots
-					and <a href="#" id="min-games-switch" onClick={onClickHelpMessage}>{{curMinGames}}</a> recorded
+					Showing {deckTypes} with at least 10 unique pilots
+					and <a href="#" id="min-games-switch" onClick={onClickHelpMessage}>{curMinGames}</a> recorded
 					games.
 				</Trans>;
 			content = (
@@ -1053,7 +1053,7 @@ class Decks extends React.Component<Props, State> {
 							}}
 						>
 							<InfoboxFilter value="MIN_GAMES">
-								{t("At least {{minGames}} games", {
+								{t("At least {minGames} games", {
 									minGames: this.getMinGames()[0],
 								})}
 							</InfoboxFilter>

--- a/hsreplaynet/static/scripts/src/pages/Decks.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Decks.tsx
@@ -1,5 +1,5 @@
+import InfoboxFilterGroup from "../components/InfoboxFilterGroup";
 import { decode as decodeDeckstring } from "deckstrings";
-import _ from "lodash";
 import React from "react";
 import { InjectedTranslateProps, Trans, translate } from "react-i18next";
 import CardData from "../CardData";
@@ -12,7 +12,7 @@ import Feature from "../components/Feature";
 import Fragments from "../components/Fragments";
 import InfoIcon from "../components/InfoIcon";
 import InfoboxFilter from "../components/InfoboxFilter";
-import InfoboxFilterGroup from "../components/InfoboxFilterGroup";
+import _ from "lodash";
 import InfoboxLastUpdated from "../components/InfoboxLastUpdated";
 import { Limit } from "../components/ObjectSearch";
 import ResetHeader from "../components/ResetHeader";
@@ -36,6 +36,7 @@ import {
 	isCollectionDisabled,
 } from "../utils/collection";
 import PrettyTimeRange from "../components/text/PrettyTimeRange";
+import PrettyRankRange from "../components/text/PrettyRankRange";
 
 interface Props extends InjectedTranslateProps, FragmentChildProps {
 	cardData: CardData | null;
@@ -858,30 +859,29 @@ class Decks extends React.Component<Props, State> {
 								iconStyle={{ display: "none" }}
 							>
 								<InfoboxFilter value={RankRange.LEGEND_ONLY}>
-									{t("Legend only")}
+									<PrettyRankRange
+										rankRange={RankRange.LEGEND_ONLY}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter
 									value={RankRange.LEGEND_THROUGH_FIVE}
 								>
-									{t("{{rankMin}}–{{rankMax}}", {
-										rankMin: t("Legend"),
-										rankMax: 5,
-									})}
+									<PrettyRankRange
+										rankRange={
+											RankRange.LEGEND_THROUGH_FIVE
+										}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter
 									value={RankRange.LEGEND_THROUGH_TEN}
 								>
-									{t("{{rankMin}}–{{rankMax}}", {
-										rankMin: t("Legend"),
-										rankMax: 10,
-									})}
+									<PrettyRankRange
+										rankRange={RankRange.LEGEND_THROUGH_TEN}
+									/>
 								</InfoboxFilter>
 							</PremiumWrapper>
 							<InfoboxFilter value={RankRange.ALL}>
-								{t("{{rankMin}}–{{rankMax}}", {
-									rankMin: t("Legend"),
-									rankMax: 25,
-								})}
+								<PrettyRankRange rankRange={RankRange.ALL} />
 							</InfoboxFilter>
 						</InfoboxFilterGroup>
 					</section>

--- a/hsreplaynet/static/scripts/src/pages/Decks.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Decks.tsx
@@ -35,6 +35,7 @@ import {
 	getDustCostForCollection,
 	isCollectionDisabled,
 } from "../utils/collection";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface Props extends InjectedTranslateProps, FragmentChildProps {
 	cardData: CardData | null;
@@ -798,23 +799,33 @@ class Decks extends React.Component<Props, State> {
 								iconStyle={{ display: "none" }}
 							>
 								<InfoboxFilter value={TimeRange.CURRENT_SEASON}>
-									{t("Current season")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_SEASON}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter value={TimeRange.LAST_3_DAYS}>
-									{t("Last {{n}} days", { n: 3 })}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_3_DAYS}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter value={TimeRange.LAST_7_DAYS}>
-									{t("Last {{n}} days", { n: 7 })}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_7_DAYS}
+									/>
 								</InfoboxFilter>
 							</PremiumWrapper>
 							<InfoboxFilter value={TimeRange.LAST_30_DAYS}>
-								{t("Last {{n}} days", { n: 30 })}
+								<PrettyTimeRange
+									timeRange={TimeRange.LAST_30_DAYS}
+								/>
 							</InfoboxFilter>
 							<Feature feature={"current-expansion-filter"}>
 								<InfoboxFilter
 									value={TimeRange.CURRENT_EXPANSION}
 								>
-									{t("The Witchwood")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_EXPANSION}
+									/>
 									<span className="infobox-value">
 										{t("New!")}
 									</span>
@@ -822,7 +833,12 @@ class Decks extends React.Component<Props, State> {
 							</Feature>
 							<Feature feature={"current-patch-filter"}>
 								<InfoboxFilter value={TimeRange.CURRENT_PATCH}>
-									{t("Latest patch")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_PATCH}
+									/>
+									<span className="infobox-value">
+										{t("New!")}
+									</span>
 								</InfoboxFilter>
 							</Feature>
 						</InfoboxFilterGroup>

--- a/hsreplaynet/static/scripts/src/pages/MetaOverview.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MetaOverview.tsx
@@ -21,6 +21,7 @@ import RankPicker from "../components/rankpicker/RankPicker";
 import { commaSeparate } from "../helpers";
 import { SortDirection } from "../interfaces";
 import { TimeRange } from "../filters";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface Props extends InjectedTranslateProps {
 	cardData: CardData;
@@ -152,20 +153,28 @@ class MetaOverview extends React.Component<Props, State> {
 								iconStyle={{ display: "none" }}
 							>
 								<InfoboxFilter value={TimeRange.LAST_1_DAY}>
-									{t("Last 1 day")}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_1_DAY}
+									/>
 								</InfoboxFilter>
 								<InfoboxFilter value={TimeRange.LAST_3_DAYS}>
-									{t("Last {{n}} days", { n: 3 })}
+									<PrettyTimeRange
+										timeRange={TimeRange.LAST_3_DAYS}
+									/>
 								</InfoboxFilter>
 							</PremiumWrapper>
 							<InfoboxFilter value={TimeRange.LAST_7_DAYS}>
-								{t("Last {{n}} days", { n: 7 })}
+								<PrettyTimeRange
+									timeRange={TimeRange.LAST_7_DAYS}
+								/>
 							</InfoboxFilter>
 							<Feature feature="current-expansion-filter">
 								<InfoboxFilter
 									value={TimeRange.CURRENT_EXPANSION}
 								>
-									{t("The Witchwood")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_EXPANSION}
+									/>
 									<span className="infobox-value">
 										{t("New!")}
 									</span>

--- a/hsreplaynet/static/scripts/src/pages/MyDecks.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyDecks.tsx
@@ -26,6 +26,7 @@ import {
 } from "../helpers";
 import { DeckObj, FragmentChildProps, TableData } from "../interfaces";
 import { TimeRange } from "../filters";
+import PrettyTimeRange from "../components/text/PrettyTimeRange";
 
 interface Props extends FragmentChildProps, InjectedTranslateProps {
 	account: Account | null;
@@ -610,19 +611,27 @@ class MyDecks extends React.Component<Props, State> {
 							onClick={value => this.props.setTimeRange(value)}
 						>
 							<InfoboxFilter value={TimeRange.PREVIOUS_SEASON}>
-								{t("Previous season")}
+								<PrettyTimeRange
+									timeRange={TimeRange.PREVIOUS_SEASON}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter value={TimeRange.CURRENT_SEASON}>
-								{t("Current season")}
+								<PrettyTimeRange
+									timeRange={TimeRange.CURRENT_SEASON}
+								/>
 							</InfoboxFilter>
 							<InfoboxFilter value={TimeRange.LAST_30_DAYS}>
-								{t("Last {{n}} days", { n: 30 })}
+								<PrettyTimeRange
+									timeRange={TimeRange.LAST_30_DAYS}
+								/>
 							</InfoboxFilter>
 							<Feature feature={"current-expansion-filter"}>
 								<InfoboxFilter
 									value={TimeRange.CURRENT_EXPANSION}
 								>
-									{t("The Witchwood")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_EXPANSION}
+									/>
 									<span className="infobox-value">
 										{t("New!")}
 									</span>
@@ -630,7 +639,9 @@ class MyDecks extends React.Component<Props, State> {
 							</Feature>
 							<Feature feature={"current-patch-filter"}>
 								<InfoboxFilter value={TimeRange.CURRENT_PATCH}>
-									{t("Latest patch")}
+									<PrettyTimeRange
+										timeRange={TimeRange.CURRENT_PATCH}
+									/>
 									<span className="infobox-value">
 										{t("New!")}
 									</span>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"hearthstonejson-client": "^0.8.1",
 		"i18next": "^11.2.2",
 		"i18next-callback-backend": "^1.0.0-alpha.1",
+		"i18next-icu": "^0.3.0",
 		"lodash": "^4.17.4",
 		"node-sass": "^4.7.2",
 		"prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,6 +2966,12 @@ i18next-callback-backend@^1.0.0-alpha.1:
   dependencies:
     invariant "^2.2.0"
 
+i18next-icu@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/i18next-icu/-/i18next-icu-0.3.0.tgz#39887b63ac17b8c859928b8aaa7f624ba06ed964"
+  dependencies:
+    intl-messageformat "2.2.0"
+
 i18next-scanner@^2.4.6:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/i18next-scanner/-/i18next-scanner-2.4.6.tgz#c0433757c227cc3517d956cb15d8339deabba4c5"
@@ -3056,6 +3062,16 @@ ini@~1.3.0:
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
+intl-messageformat-parser@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
+
+intl-messageformat@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
+  dependencies:
+    intl-messageformat-parser "1.4.0"
 
 invariant@^2.2.0:
   version "2.2.4"


### PR DESCRIPTION
This replaces i18next's text formatting with ICU. ICU is a [powerful formatting syntax](http://userguide.icu-project.org/formatparse/messages), which supports plurals amongst other things. It's [supported and validated natively by Crowdin](https://blog.crowdin.com/2016/11/09/icu-syntax-in-crowdin/).

I've also DRY'd the whole `{{minRank}}/{{maxRank}}` stuff and time ranges.

Closes #780.
