### PR TITLE
Translate js/ts strings outside of a React context

### DIFF
--- a/hsreplaynet/static/scripts/src/JoustEmbedder.ts
+++ b/hsreplaynet/static/scripts/src/JoustEmbedder.ts
@@ -10,6 +10,7 @@ import { cardArt, joustAsset, joustStaticFile } from "./helpers";
 import BatchingMiddleware from "./metrics/BatchingMiddleware";
 import InfluxMetricsBackend from "./metrics/InfluxMetricsBackend";
 import MetricsReporter from "./metrics/MetricsReporter";
+import { TranslationFunction } from "react-i18next";
 
 export default class JoustEmbedder {
 	public turn: number = null;
@@ -21,12 +22,12 @@ export default class JoustEmbedder {
 	public onToggleReveal: (reveal: boolean) => void = null;
 	private url: string = null;
 
-	public embed(target: HTMLElement) {
-		this.prepare(target);
+	public embed(target: HTMLElement, t: TranslationFunction) {
+		this.prepare(target, t);
 		this.render();
 	}
 
-	public prepare(target: HTMLElement) {
+	public prepare(target: HTMLElement, t: TranslationFunction) {
 		// find container
 		if (!target) {
 			throw new Error("No target specified");
@@ -37,10 +38,16 @@ export default class JoustEmbedder {
 			const joustUrl = joustStaticFile("joust.js");
 			target.innerHTML =
 				'<p class="alert alert-danger">' +
-				"<strong>Loading failed:</strong> " +
-				"Replay applet (Joust) could not be loaded. Please ensure you can access " +
-				`<a href="${joustUrl}">${joustUrl}</a>.</p>` +
-				"<p>Otherwise try clearing your cache and refreshing this page.</p>";
+				`<strong>${t("Loading failed:")}</strong> ` +
+				`<p>${t(
+					"Replay applet (Joust) could not be loaded. Please ensure you can access {joustUrl}.",
+					{
+						joustUrl: `<a href="${joustUrl}">${joustUrl}</a>`,
+					},
+				)}</p>` +
+				`<p>${t(
+					"Otherwise try clearing your cache and refreshing this page.",
+				)}</p>`;
 			// could also offer document.location.reload(true)
 			return;
 		}

--- a/hsreplaynet/static/scripts/src/TourManager.ts
+++ b/hsreplaynet/static/scripts/src/TourManager.ts
@@ -1,5 +1,6 @@
 import { cookie } from "cookie_js";
 import Shepherd from "tether-shepherd";
+import { TranslationFunction} from "react-i18next";
 
 export interface StepDefinition {
 	id: string;
@@ -12,6 +13,7 @@ export default class TourManager {
 	public createTour(
 		name: string,
 		steps: StepDefinition[],
+		t: TranslationFunction,
 		customDefaults?: object,
 		force?: boolean,
 	): Shepherd.Tour {
@@ -50,20 +52,20 @@ export default class TourManager {
 
 			if (!first) {
 				buttons.push({
-					text: "Back",
+					text: t("Back"),
 					classes: "btn btn-default",
 					action: () => tour.back(),
 				});
 			}
 			if (last) {
 				buttons.push({
-					text: "Done",
+					text: t("Done"),
 					classes: "btn btn-success",
 					action: () => tour.complete(),
 				});
 			} else {
 				buttons.push({
-					text: "Next",
+					text: t("Next"),
 					classes: "btn btn-primary",
 					action: () => tour.next(),
 				});

--- a/hsreplaynet/static/scripts/src/TourManager.ts
+++ b/hsreplaynet/static/scripts/src/TourManager.ts
@@ -1,6 +1,6 @@
 import { cookie } from "cookie_js";
 import Shepherd from "tether-shepherd";
-import { TranslationFunction} from "react-i18next";
+import { TranslationFunction } from "react-i18next";
 
 export interface StepDefinition {
 	id: string;

--- a/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
+++ b/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import { InjectedTranslateProps, translate } from "react-i18next";
 import CardData from "../CardData";
 import { FormatType } from "../hearthstone";
-import { getHeroClassName } from "../helpers";
 import Tooltip from "./Tooltip";
+import {getHeroClassName} from "../helpers";
 
 interface Props extends InjectedTranslateProps {
 	cardData: CardData;
@@ -154,7 +154,7 @@ class CopyDeckButton extends React.Component<Props, State> {
 		}
 
 		const deckName = this.props.name || t("HSReplay.net Deck");
-		const className = getHeroClassName(this.props.deckClass || "NEUTRAL");
+		const className = getHeroClassName(this.props.deckClass || "NEUTRAL", t);
 		const deckUrl = this.props.sourceUrl || "https://hsreplay.net/decks/";
 		const formatName = format === 2 ? t("Standard") : t("Wild");
 

--- a/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
+++ b/hsreplaynet/static/scripts/src/components/CopyDeckButton.tsx
@@ -6,7 +6,7 @@ import { InjectedTranslateProps, translate } from "react-i18next";
 import CardData from "../CardData";
 import { FormatType } from "../hearthstone";
 import Tooltip from "./Tooltip";
-import {getHeroClassName} from "../helpers";
+import { getHeroClassName } from "../helpers";
 
 interface Props extends InjectedTranslateProps {
 	cardData: CardData;
@@ -154,7 +154,10 @@ class CopyDeckButton extends React.Component<Props, State> {
 		}
 
 		const deckName = this.props.name || t("HSReplay.net Deck");
-		const className = getHeroClassName(this.props.deckClass || "NEUTRAL", t);
+		const className = getHeroClassName(
+			this.props.deckClass || "NEUTRAL",
+			t,
+		);
 		const deckUrl = this.props.sourceUrl || "https://hsreplay.net/decks/";
 		const formatName = format === 2 ? t("Standard") : t("Wild");
 

--- a/hsreplaynet/static/scripts/src/components/DeckTile.tsx
+++ b/hsreplaynet/static/scripts/src/components/DeckTile.tsx
@@ -190,7 +190,7 @@ class DeckTile extends React.Component<Props> {
 
 		const deckName = this.props.archetypeName
 			? this.props.archetypeName
-			: getHeroClassName(this.props.playerClass);
+			: getHeroClassName(this.props.playerClass, t);
 
 		let globalDataIndicator = null;
 		if (this.props.hasGlobalData) {

--- a/hsreplaynet/static/scripts/src/components/PlayerInfo.tsx
+++ b/hsreplaynet/static/scripts/src/components/PlayerInfo.tsx
@@ -341,10 +341,11 @@ class PlayerInfo extends React.Component<Props, State> {
 	}
 
 	getDeckName(player: GlobalGamePlayer): string {
+		const { t } = this.props;
 		return (
 			this.pluralize(player.name) +
 			" " +
-			getHeroClassName(player.hero_class_name)
+			getHeroClassName(player.hero_class_name, t)
 		);
 	}
 

--- a/hsreplaynet/static/scripts/src/components/archetypedetail/ArchetypeDistributionPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/archetypedetail/ArchetypeDistributionPieChart.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import {
-	getHeroClassName,
 	getHeroColor,
 	hexToHsl,
 	stringifyHsl,
 } from "../../helpers";
 import { VictoryLabel, VictoryLegend, VictoryPie } from "victory";
 import { Archetype } from "../../utils/api";
+import { getHeroClassName } from "../../helpers";
+import {
+	InjectedTranslateProps,
+	translate,
+} from "react-i18next";
 
-interface ArchetypeDistributionPieChartProps {
+interface ArchetypeDistributionPieChartProps extends InjectedTranslateProps {
 	matchupData?: any;
 	archetypeData?: any;
 	selectedArchetypeId?: number;
@@ -21,7 +25,7 @@ interface ArchetypeDistributionPieChartState {
 
 const pageBackground: string = "#fbf7f6";
 
-export default class ArchetypeDistributionPieChart extends React.Component<
+class ArchetypeDistributionPieChart extends React.Component<
 	ArchetypeDistributionPieChartProps,
 	ArchetypeDistributionPieChartState
 > {
@@ -40,9 +44,12 @@ export default class ArchetypeDistributionPieChart extends React.Component<
 	}
 
 	private getArchetypeName(archetype: Archetype): string {
+		const { t } = this.props;
 		return archetype
 			? archetype.name
-			: `Other ${getHeroClassName(this.props.playerClass)}`;
+			: t("Other {cardClass}", {
+				cardClass: getHeroClassName(this.props.playerClass, t)
+			});
 	}
 
 	private getChartData(): any {
@@ -94,6 +101,7 @@ export default class ArchetypeDistributionPieChart extends React.Component<
 	}
 
 	public render(): React.ReactNode {
+		const { t } = this.props;
 		const data = this.getChartData();
 		const legendData = data.map(p => {
 			const hovering = p.archetypeId === this.state.hovering;
@@ -157,7 +165,7 @@ export default class ArchetypeDistributionPieChart extends React.Component<
 					x={200}
 					y={20}
 					text={`${getHeroClassName(
-						this.props.playerClass,
+						this.props.playerClass, t
 					)} Archetypes`}
 					style={{ fontSize: 20 }}
 				/>
@@ -212,3 +220,5 @@ export default class ArchetypeDistributionPieChart extends React.Component<
 		];
 	}
 }
+
+export default translate()(ArchetypeDistributionPieChart);

--- a/hsreplaynet/static/scripts/src/components/archetypedetail/ArchetypeDistributionPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/archetypedetail/ArchetypeDistributionPieChart.tsx
@@ -1,16 +1,9 @@
 import React from "react";
-import {
-	getHeroColor,
-	hexToHsl,
-	stringifyHsl,
-} from "../../helpers";
+import { getHeroColor, hexToHsl, stringifyHsl } from "../../helpers";
 import { VictoryLabel, VictoryLegend, VictoryPie } from "victory";
 import { Archetype } from "../../utils/api";
 import { getHeroClassName } from "../../helpers";
-import {
-	InjectedTranslateProps,
-	translate,
-} from "react-i18next";
+import { InjectedTranslateProps, translate } from "react-i18next";
 
 interface ArchetypeDistributionPieChartProps extends InjectedTranslateProps {
 	matchupData?: any;
@@ -48,8 +41,8 @@ class ArchetypeDistributionPieChart extends React.Component<
 		return archetype
 			? archetype.name
 			: t("Other {cardClass}", {
-				cardClass: getHeroClassName(this.props.playerClass, t)
-			});
+					cardClass: getHeroClassName(this.props.playerClass, t),
+			  });
 	}
 
 	private getChartData(): any {
@@ -165,7 +158,8 @@ class ArchetypeDistributionPieChart extends React.Component<
 					x={200}
 					y={20}
 					text={`${getHeroClassName(
-						this.props.playerClass, t
+						this.props.playerClass,
+						t,
 					)} Archetypes`}
 					style={{ fontSize: 20 }}
 				/>

--- a/hsreplaynet/static/scripts/src/components/charts/CardDetailBarChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/CardDetailBarChart.tsx
@@ -8,10 +8,7 @@ import {
 } from "victory";
 import { RenderData } from "../../interfaces";
 import { getChartScheme } from "../../helpers";
-import {
-	InjectedTranslateProps,
-	translate
-} from "react-i18next";
+import { InjectedTranslateProps, translate } from "react-i18next";
 
 interface Props extends InjectedTranslateProps {
 	data?: RenderData;
@@ -108,4 +105,4 @@ class CardDetailBarChart extends React.Component<Props> {
 	}
 }
 
-export default translate()(CardDetailBarChart)
+export default translate()(CardDetailBarChart);

--- a/hsreplaynet/static/scripts/src/components/charts/CardDetailBarChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/CardDetailBarChart.tsx
@@ -8,8 +8,12 @@ import {
 } from "victory";
 import { RenderData } from "../../interfaces";
 import { getChartScheme } from "../../helpers";
+import {
+	InjectedTranslateProps,
+	translate
+} from "react-i18next";
 
-interface Props {
+interface Props extends InjectedTranslateProps {
 	data?: RenderData;
 	title?: string;
 	labelX?: string;
@@ -18,7 +22,7 @@ interface Props {
 	showYAxis?: boolean;
 }
 
-export default class CardDetailBarChart extends React.Component<Props> {
+class CardDetailBarChart extends React.Component<Props> {
 	public render(): React.ReactNode {
 		const width = 150 * (this.props.widthRatio || 3);
 		const series = this.props.data.series[0];
@@ -31,7 +35,7 @@ export default class CardDetailBarChart extends React.Component<Props> {
 		if (series.metadata) {
 			const schemeName = series.metadata["chart_scheme"];
 			if (schemeName) {
-				scheme = getChartScheme(schemeName);
+				scheme = getChartScheme(schemeName, this.props.t);
 				if (scheme) {
 					fill = prop => scheme[prop.xName.toLowerCase()].fill;
 					stroke = prop => scheme[prop.xName.toLowerCase()].stroke;
@@ -103,3 +107,5 @@ export default class CardDetailBarChart extends React.Component<Props> {
 		);
 	}
 }
+
+export default translate()(CardDetailBarChart)

--- a/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
@@ -7,10 +7,7 @@ import {
 } from "victory";
 import { getChartScheme, pieScaleTransform, toTitleCase } from "../../helpers";
 import { ChartScheme, RenderData } from "../../interfaces";
-import {
-	InjectedTranslateProps,
-	translate
-} from "react-i18next";
+import { InjectedTranslateProps, translate } from "react-i18next";
 
 interface Props extends InjectedTranslateProps {
 	data?: RenderData;
@@ -33,7 +30,10 @@ class CardDetailPieChart extends React.Component<Props> {
 		const legendData = [];
 
 		if (!scheme && series.metadata && series.metadata["chart_scheme"]) {
-			scheme = getChartScheme(series.metadata["chart_scheme"], this.props.t);
+			scheme = getChartScheme(
+				series.metadata["chart_scheme"],
+				this.props.t,
+			);
 		}
 
 		if (scheme) {
@@ -184,4 +184,4 @@ class CardDetailPieChart extends React.Component<Props> {
 	}
 }
 
-export default translate()(CardDetailPieChart)
+export default translate()(CardDetailPieChart);

--- a/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
@@ -7,8 +7,12 @@ import {
 } from "victory";
 import { getChartScheme, pieScaleTransform, toTitleCase } from "../../helpers";
 import { ChartScheme, RenderData } from "../../interfaces";
+import {
+	InjectedTranslateProps,
+	translate
+} from "react-i18next";
 
-interface Props {
+interface Props extends InjectedTranslateProps {
 	data?: RenderData;
 	title?: string;
 	scheme?: ChartScheme;
@@ -19,7 +23,7 @@ interface Props {
 	customViewbox?: string;
 }
 
-export default class CardDetailPieChart extends React.Component<Props> {
+class CardDetailPieChart extends React.Component<Props> {
 	public render(): React.ReactNode {
 		const series = this.props.data.series[0];
 		let data = series.data;
@@ -29,7 +33,7 @@ export default class CardDetailPieChart extends React.Component<Props> {
 		const legendData = [];
 
 		if (!scheme && series.metadata && series.metadata["chart_scheme"]) {
-			scheme = getChartScheme(series.metadata["chart_scheme"]);
+			scheme = getChartScheme(series.metadata["chart_scheme"], this.props.t);
 		}
 
 		if (scheme) {
@@ -179,3 +183,5 @@ export default class CardDetailPieChart extends React.Component<Props> {
 		);
 	}
 }
+
+export default translate()(CardDetailPieChart)

--- a/hsreplaynet/static/scripts/src/components/discover/ClassAnalysis.tsx
+++ b/hsreplaynet/static/scripts/src/components/discover/ClassAnalysis.tsx
@@ -124,6 +124,7 @@ class ClassAnalysis extends React.Component<Props, State> {
 					title: t("Interaction"),
 				},
 			],
+			t,
 			null,
 			force,
 		);

--- a/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypeMatchups.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypeMatchups.tsx
@@ -14,8 +14,12 @@ import { withLoading } from "../loading/Loading";
 import LowDataWarning from "./LowDataWarning";
 import ArchetypeMatrix from "./matchups/ArchetypeMatrix";
 import { isEligibleMatchup } from "./matchups/MatchupCell";
+import {
+	InjectedTranslateProps,
+	translate
+} from "react-i18next";
 
-interface Props {
+interface Props extends InjectedTranslateProps {
 	archetypeData?: any;
 	cardData: CardData;
 	gameType: string;
@@ -435,7 +439,8 @@ class ArchetypeMatchups extends React.Component<Props, State> {
 	}
 
 	getApiArchetype(id: number, archetypeData: any): Archetype {
-		return archetypeData.find(a => a.id === id) || getOtherArchetype(id);
+		const { t } = this.props;
+		return archetypeData.find(a => a.id === id) || getOtherArchetype(id, t);
 	}
 
 	getMatchup(
@@ -462,5 +467,5 @@ class ArchetypeMatchups extends React.Component<Props, State> {
 }
 
 export default withLoading(["archetypeData", "matchupData", "popularityData"])(
-	ArchetypeMatchups,
+	translate()(ArchetypeMatchups),
 );

--- a/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypeMatchups.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypeMatchups.tsx
@@ -14,10 +14,7 @@ import { withLoading } from "../loading/Loading";
 import LowDataWarning from "./LowDataWarning";
 import ArchetypeMatrix from "./matchups/ArchetypeMatrix";
 import { isEligibleMatchup } from "./matchups/MatchupCell";
-import {
-	InjectedTranslateProps,
-	translate
-} from "react-i18next";
+import { InjectedTranslateProps, translate } from "react-i18next";
 
 interface Props extends InjectedTranslateProps {
 	archetypeData?: any;

--- a/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypePopularity.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypePopularity.tsx
@@ -10,10 +10,7 @@ import { withLoading } from "../loading/Loading";
 import PopularityMatrix from "./popularity/PopularityMatrix";
 import { getOtherArchetype } from "../../helpers";
 import { Archetype } from "../../utils/api";
-import {
-	InjectedTranslateProps,
-	translate
-} from "react-i18next";
+import { InjectedTranslateProps, translate } from "react-i18next";
 
 interface Props extends InjectedTranslateProps {
 	archetypeData?: any;

--- a/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypePopularity.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/ArchetypePopularity.tsx
@@ -10,8 +10,12 @@ import { withLoading } from "../loading/Loading";
 import PopularityMatrix from "./popularity/PopularityMatrix";
 import { getOtherArchetype } from "../../helpers";
 import { Archetype } from "../../utils/api";
+import {
+	InjectedTranslateProps,
+	translate
+} from "react-i18next";
 
-interface Props {
+interface Props extends InjectedTranslateProps {
 	archetypeData?: any;
 	cardData: CardData;
 	gameType: string;
@@ -157,13 +161,14 @@ class ArchetypePopularity extends React.Component<Props> {
 	}
 
 	getApiArchetype(id: number): Archetype {
+		const { t } = this.props;
 		return (
 			this.props.archetypeData.find(a => a.id === id) ||
-			getOtherArchetype(id)
+			getOtherArchetype(id, t)
 		);
 	}
 }
 
 export default withLoading(["archetypeData", "popularityData"])(
-	ArchetypePopularity,
+	translate()(ArchetypePopularity),
 );

--- a/hsreplaynet/static/scripts/src/components/tables/CardTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/tables/CardTable.tsx
@@ -4,7 +4,7 @@ import Table, { AnnotatedNumber } from "./Table";
 import { CardObj, SortableProps } from "../../interfaces";
 import { withLoading } from "../loading/Loading";
 import {
-	cardTableColumnData,
+	getCardTableColumnData,
 	CardTableColumnKey,
 } from "./cardtable/CardTableColumns";
 import {
@@ -13,8 +13,9 @@ import {
 } from "./cardtable/RowDataGenerator";
 import { isMissingCardFromCollection } from "../../utils/collection";
 import { Collection } from "../../utils/api";
+import { InjectedTranslateProps } from "react-i18next";
 
-interface Props extends SortableProps {
+interface Props extends SortableProps, InjectedTranslateProps{
 	baseWinrate?: number;
 	cards?: CardObj[];
 	columns: CardTableColumnKey[];
@@ -47,9 +48,10 @@ class CardTable extends React.Component<Props> {
 			numCards,
 			minColumnWidth,
 			headerWidth,
+			t,
 		} = this.props;
 		const columnKeys = ["card"].concat(this.props.columns);
-		const columns = columnKeys.map(key => cardTableColumnData[key]);
+		const columns = columnKeys.map(key => getCardTableColumnData(t)[key]);
 		let rowData = generateCardTableRowData(
 			cards,
 			data,

--- a/hsreplaynet/static/scripts/src/components/tables/CardTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/tables/CardTable.tsx
@@ -4,8 +4,8 @@ import Table, { AnnotatedNumber } from "./Table";
 import { CardObj, SortableProps } from "../../interfaces";
 import { withLoading } from "../loading/Loading";
 import {
-	getCardTableColumnData,
 	CardTableColumnKey,
+	getCardTableColumnData,
 } from "./cardtable/CardTableColumns";
 import {
 	ApiCardStatsData,
@@ -15,7 +15,7 @@ import { isMissingCardFromCollection } from "../../utils/collection";
 import { Collection } from "../../utils/api";
 import { InjectedTranslateProps } from "react-i18next";
 
-interface Props extends SortableProps, InjectedTranslateProps{
+interface Props extends SortableProps, InjectedTranslateProps {
 	baseWinrate?: number;
 	cards?: CardObj[];
 	columns: CardTableColumnKey[];

--- a/hsreplaynet/static/scripts/src/components/tables/cardtable/CardTableColumns.ts
+++ b/hsreplaynet/static/scripts/src/components/tables/cardtable/CardTableColumns.ts
@@ -1,5 +1,5 @@
 import { TableColumn } from "../Table";
-import {TranslationFunction} from "i18next";
+import { TranslationFunction } from "i18next";
 
 export type CardTableColumnKey =
 	| "card"
@@ -25,181 +25,181 @@ export type CardTableColumnKey =
 	| "winrate"
 	| "prevalence";
 
-export function getCardTableColumnData(t: TranslationFunction): {
-	[key in CardTableColumnKey]: TableColumn
-} {
+export function getCardTableColumnData(
+	t: TranslationFunction,
+): { [key in CardTableColumnKey]: TableColumn } {
 	return {
 		card: {
 			dataKey: "card",
-				defaultSortDirection: "ascending",
-				sortKey: "card",
-				text: t("Card"),
+			defaultSortDirection: "ascending",
+			sortKey: "card",
+			text: t("Card"),
 		},
 		mulliganWinrate: {
 			dataKey: "opening_hand_winrate",
-				infoHeader: t("Mulligan winrate"),
-				infoText: t(
+			infoHeader: t("Mulligan winrate"),
+			infoText: t(
 				"Average winrate of games when the card ended up in the opening hand.",
 			),
-				lowDataKey: "times_in_opening_hand",
-				lowDataValue: 100,
-				lowDataWarning: t("Low data. Winrate might be inaccurate."),
-				sortKey: "mulliganWinrate",
-				text: t("Mulligan WR"),
-				winrateData: true,
+			lowDataKey: "times_in_opening_hand",
+			lowDataValue: 100,
+			lowDataWarning: t("Low data. Winrate might be inaccurate."),
+			sortKey: "mulliganWinrate",
+			text: t("Mulligan WR"),
+			winrateData: true,
 		},
 		keepPercent: {
 			dataKey: "keep_percentage",
-				infoHeader: t("Kept"),
-				infoText: t(
+			infoHeader: t("Kept"),
+			infoText: t(
 				"Percentage of times the card was kept when presented during mulligan.",
 			),
-				percent: true,
-				sortKey: "keepPercent",
-				text: t("Kept"),
+			percent: true,
+			sortKey: "keepPercent",
+			text: t("Kept"),
 		},
 		drawnWinrate: {
 			dataKey: "winrate_when_drawn",
-				infoHeader: t("Drawn winrate"),
-				infoText: t(
+			infoHeader: t("Drawn winrate"),
+			infoText: t(
 				"Average winrate of games where the card was drawn at any point or ended up in the opening hand.",
 			),
-				sortKey: "drawnWinrate",
-				text: t("Drawn WR"),
-				winrateData: true,
+			sortKey: "drawnWinrate",
+			text: t("Drawn WR"),
+			winrateData: true,
 		},
 		playedWinrate: {
 			dataKey: "winrate_when_played",
-				infoHeader: t("Played winrate"),
-				infoText: t(
+			infoHeader: t("Played winrate"),
+			infoText: t(
 				"Average winrate of games where the card was played at any point.",
 			),
-				sortKey: "playedWinrate",
-				text: t("Played WR"),
-				winrateData: true,
+			sortKey: "playedWinrate",
+			text: t("Played WR"),
+			winrateData: true,
 		},
 		turnsInHand: {
 			dataKey: "avg_turns_in_hand",
-				infoHeader: t("Turns held"),
-				infoText: t("Average number of turns the card was held in hand."),
-				sortKey: "turnsInHand",
-				text: t("Turns held"),
+			infoHeader: t("Turns held"),
+			infoText: t("Average number of turns the card was held in hand."),
+			sortKey: "turnsInHand",
+			text: t("Turns held"),
 		},
 		turnPlayed: {
 			dataKey: "avg_turn_played_on",
-				infoHeader: t("Turn played"),
-				infoText: t("Average turn the card was played on."),
-				sortKey: "turnPlayed",
-				text: t("Turn played"),
+			infoHeader: t("Turn played"),
+			infoText: t("Average turn the card was played on."),
+			sortKey: "turnPlayed",
+			text: t("Turn played"),
 		},
 		timesPlayedPersonal: {
 			dataKey: "times_played",
-				infoHeader: t("Times played"),
-				infoText: t("Number of times you played the card."),
-				sortKey: "timesPlayed",
-				text: t("Times played"),
+			infoHeader: t("Times played"),
+			infoText: t("Number of times you played the card."),
+			sortKey: "timesPlayed",
+			text: t("Times played"),
 		},
 		damageDone: {
 			dataKey: "damage_done",
-				infoHeader: t("Damage done"),
-				infoText: t(
+			infoHeader: t("Damage done"),
+			infoText: t(
 				"Total amount of damage the card has dealt. Does not include overkills.",
 			),
-				sortKey: "damageDone",
-				text: t("Damage done"),
+			sortKey: "damageDone",
+			text: t("Damage done"),
 		},
 		healingDone: {
 			dataKey: "healing_done",
-				infoHeader: t("Healing done"),
-				infoText: t(
+			infoHeader: t("Healing done"),
+			infoText: t(
 				"Total amount of healing the card has done. Does not include overhealing.",
 			),
-				sortKey: "healingDone",
-				text: t("Healing done"),
+			sortKey: "healingDone",
+			text: t("Healing done"),
 		},
 		heroesKilled: {
 			dataKey: "heroes_killed",
-				infoHeader: t("Heroes killed"),
-				infoText: t("Number of heroes the card has killed."),
-				sortKey: "heroesKilled",
-				text: t("Heroes killed"),
+			infoHeader: t("Heroes killed"),
+			infoText: t("Number of heroes the card has killed."),
+			sortKey: "heroesKilled",
+			text: t("Heroes killed"),
 		},
 		minionsKilled: {
 			dataKey: "minions_killed",
-				infoHeader: t("Minions killed"),
-				infoText: t("Number of minions the card has killed."),
-				sortKey: "minionsKilled",
-				text: t("Minions killed"),
+			infoHeader: t("Minions killed"),
+			infoText: t("Number of minions the card has killed."),
+			sortKey: "minionsKilled",
+			text: t("Minions killed"),
 		},
 		totalGames: {
 			dataKey: "total_games",
-				infoHeader: t("Total games"),
-				infoText: t(
+			infoHeader: t("Total games"),
+			infoText: t(
 				"Number of games you played with a deck that included the card.",
 			),
-				sortKey: "totalGames",
-				text: t("Total games"),
+			sortKey: "totalGames",
+			text: t("Total games"),
 		},
 		winrate: {
 			dataKey: "winrate",
-				infoHeader: t("Winrate"),
-				infoText: t("Winrate of decks including the card."),
-				sortKey: "winrate",
-				text: t("Winrate"),
-				winrateData: true,
+			infoHeader: t("Winrate"),
+			infoText: t("Winrate of decks including the card."),
+			sortKey: "winrate",
+			text: t("Winrate"),
+			winrateData: true,
 		},
 		distinctDecks: {
 			dataKey: "distinct_decks",
-				infoHeader: t("Distinct decks"),
-				infoText: t("Number of distinct decks you included the card in."),
-				sortKey: "distinctDecks",
-				text: t("Distinct decks"),
+			infoHeader: t("Distinct decks"),
+			infoText: t("Number of distinct decks you included the card in."),
+			sortKey: "distinctDecks",
+			text: t("Distinct decks"),
 		},
 		includedPopularity: {
 			dataKey: "included_popularity",
-				infoHeader: t("Included in % of decks"),
-				infoText: t(
+			infoHeader: t("Included in % of decks"),
+			infoText: t(
 				"Percentage of decks that include at least one copy of this card.",
 			),
-				percent: true,
-				sortKey: "includedPopularity",
-				text: t("In % of decks"),
+			percent: true,
+			sortKey: "includedPopularity",
+			text: t("In % of decks"),
 		},
 		includedCount: {
 			dataKey: "included_count",
-				infoHeader: t("Copies in deck"),
-				infoText: t("Average number of copies in a deck."),
-				sortKey: "includedCount",
-				text: t("Copies"),
+			infoHeader: t("Copies in deck"),
+			infoText: t("Average number of copies in a deck."),
+			sortKey: "includedCount",
+			text: t("Copies"),
 		},
 		includedWinrate: {
 			dataKey: "included_winrate",
-				infoHeader: t("Deck winrate"),
-				infoText: t("Average winrate of decks that include this card."),
-				sortKey: "includedWinrate",
-				text: t("Deck winrate"),
-				winrateData: true,
+			infoHeader: t("Deck winrate"),
+			infoText: t("Average winrate of decks that include this card."),
+			sortKey: "includedWinrate",
+			text: t("Deck winrate"),
+			winrateData: true,
 		},
 		timesPlayedTotal: {
 			dataKey: "times_played",
-				infoHeader: t("Times played"),
-				infoText: t("Number of times the card was played."),
-				prettify: true,
-				sortKey: "timesPlayed",
-				text: t("Times played"),
+			infoHeader: t("Times played"),
+			infoText: t("Number of times the card was played."),
+			prettify: true,
+			sortKey: "timesPlayed",
+			text: t("Times played"),
 		},
 		playedPopularity: {
 			dataKey: "played_popularity",
-				infoHeader: t("% of played cards"),
-				infoText: t("Percentage of all cards played."),
-				percent: true,
-				sortKey: "timesPlayed",
-				text: t("% of played cards"),
+			infoHeader: t("% of played cards"),
+			infoText: t("Percentage of all cards played."),
+			percent: true,
+			sortKey: "timesPlayed",
+			text: t("% of played cards"),
 		},
 		prevalence: {
 			dataKey: "prevalence",
-				sortKey: "prevalence",
-				text: t("Prevalence"),
+			sortKey: "prevalence",
+			text: t("Prevalence"),
 		},
-	}
-};
+	};
+}

--- a/hsreplaynet/static/scripts/src/components/tables/cardtable/CardTableColumns.ts
+++ b/hsreplaynet/static/scripts/src/components/tables/cardtable/CardTableColumns.ts
@@ -1,4 +1,5 @@
 import { TableColumn } from "../Table";
+import {TranslationFunction} from "i18next";
 
 export type CardTableColumnKey =
 	| "card"
@@ -24,182 +25,181 @@ export type CardTableColumnKey =
 	| "winrate"
 	| "prevalence";
 
-const t = (s: string) => s;
-
-/* FIXME i18n */
-export const cardTableColumnData: {
+export function getCardTableColumnData(t: TranslationFunction): {
 	[key in CardTableColumnKey]: TableColumn
-} = {
-	card: {
-		dataKey: "card",
-		defaultSortDirection: "ascending",
-		sortKey: "card",
-		text: t("Card"),
-	},
-	mulliganWinrate: {
-		dataKey: "opening_hand_winrate",
-		infoHeader: t("Mulligan winrate"),
-		infoText: t(
-			"Average winrate of games when the card ended up in the opening hand.",
-		),
-		lowDataKey: "times_in_opening_hand",
-		lowDataValue: 100,
-		lowDataWarning: t("Low data. Winrate might be inaccurate."),
-		sortKey: "mulliganWinrate",
-		text: t("Mulligan WR"),
-		winrateData: true,
-	},
-	keepPercent: {
-		dataKey: "keep_percentage",
-		infoHeader: t("Kept"),
-		infoText: t(
-			"Percentage of times the card was kept when presented during mulligan.",
-		),
-		percent: true,
-		sortKey: "keepPercent",
-		text: t("Kept"),
-	},
-	drawnWinrate: {
-		dataKey: "winrate_when_drawn",
-		infoHeader: t("Drawn winrate"),
-		infoText: t(
-			"Average winrate of games where the card was drawn at any point or ended up in the opening hand.",
-		),
-		sortKey: "drawnWinrate",
-		text: t("Drawn WR"),
-		winrateData: true,
-	},
-	playedWinrate: {
-		dataKey: "winrate_when_played",
-		infoHeader: t("Played winrate"),
-		infoText: t(
-			"Average winrate of games where the card was played at any point.",
-		),
-		sortKey: "playedWinrate",
-		text: t("Played WR"),
-		winrateData: true,
-	},
-	turnsInHand: {
-		dataKey: "avg_turns_in_hand",
-		infoHeader: t("Turns held"),
-		infoText: t("Average number of turns the card was held in hand."),
-		sortKey: "turnsInHand",
-		text: t("Turns held"),
-	},
-	turnPlayed: {
-		dataKey: "avg_turn_played_on",
-		infoHeader: t("Turn played"),
-		infoText: t("Average turn the card was played on."),
-		sortKey: "turnPlayed",
-		text: t("Turn played"),
-	},
-	timesPlayedPersonal: {
-		dataKey: "times_played",
-		infoHeader: t("Times played"),
-		infoText: t("Number of times you played the card."),
-		sortKey: "timesPlayed",
-		text: t("Times played"),
-	},
-	damageDone: {
-		dataKey: "damage_done",
-		infoHeader: t("Damage done"),
-		infoText: t(
-			"Total amount of damage the card has dealt. Does not include overkills.",
-		),
-		sortKey: "damageDone",
-		text: t("Damage done"),
-	},
-	healingDone: {
-		dataKey: "healing_done",
-		infoHeader: t("Healing done"),
-		infoText: t(
-			"Total amount of healing the card has done. Does not include overhealing.",
-		),
-		sortKey: "healingDone",
-		text: t("Healing done"),
-	},
-	heroesKilled: {
-		dataKey: "heroes_killed",
-		infoHeader: t("Heroes killed"),
-		infoText: t("Number of heroes the card has killed."),
-		sortKey: "heroesKilled",
-		text: t("Heroes killed"),
-	},
-	minionsKilled: {
-		dataKey: "minions_killed",
-		infoHeader: t("Minions killed"),
-		infoText: t("Number of minions the card has killed."),
-		sortKey: "minionsKilled",
-		text: t("Minions killed"),
-	},
-	totalGames: {
-		dataKey: "total_games",
-		infoHeader: t("Total games"),
-		infoText: t(
-			"Number of games you played with a deck that included the card.",
-		),
-		sortKey: "totalGames",
-		text: t("Total games"),
-	},
-	winrate: {
-		dataKey: "winrate",
-		infoHeader: t("Winrate"),
-		infoText: t("Winrate of decks including the card."),
-		sortKey: "winrate",
-		text: t("Winrate"),
-		winrateData: true,
-	},
-	distinctDecks: {
-		dataKey: "distinct_decks",
-		infoHeader: t("Distinct decks"),
-		infoText: t("Number of distinct decks you included the card in."),
-		sortKey: "distinctDecks",
-		text: t("Distinct decks"),
-	},
-	includedPopularity: {
-		dataKey: "included_popularity",
-		infoHeader: t("Included in % of decks"),
-		infoText: t(
-			"Percentage of decks that include at least one copy of this card.",
-		),
-		percent: true,
-		sortKey: "includedPopularity",
-		text: t("In % of decks"),
-	},
-	includedCount: {
-		dataKey: "included_count",
-		infoHeader: t("Copies in deck"),
-		infoText: t("Average number of copies in a deck."),
-		sortKey: "includedCount",
-		text: t("Copies"),
-	},
-	includedWinrate: {
-		dataKey: "included_winrate",
-		infoHeader: t("Deck winrate"),
-		infoText: t("Average winrate of decks that include this card."),
-		sortKey: "includedWinrate",
-		text: t("Deck winrate"),
-		winrateData: true,
-	},
-	timesPlayedTotal: {
-		dataKey: "times_played",
-		infoHeader: t("Times played"),
-		infoText: t("Number of times the card was played."),
-		prettify: true,
-		sortKey: "timesPlayed",
-		text: t("Times played"),
-	},
-	playedPopularity: {
-		dataKey: "played_popularity",
-		infoHeader: t("% of played cards"),
-		infoText: t("Percentage of all cards played."),
-		percent: true,
-		sortKey: "timesPlayed",
-		text: t("% of played cards"),
-	},
-	prevalence: {
-		dataKey: "prevalence",
-		sortKey: "prevalence",
-		text: t("Prevalence"),
-	},
+} {
+	return {
+		card: {
+			dataKey: "card",
+				defaultSortDirection: "ascending",
+				sortKey: "card",
+				text: t("Card"),
+		},
+		mulliganWinrate: {
+			dataKey: "opening_hand_winrate",
+				infoHeader: t("Mulligan winrate"),
+				infoText: t(
+				"Average winrate of games when the card ended up in the opening hand.",
+			),
+				lowDataKey: "times_in_opening_hand",
+				lowDataValue: 100,
+				lowDataWarning: t("Low data. Winrate might be inaccurate."),
+				sortKey: "mulliganWinrate",
+				text: t("Mulligan WR"),
+				winrateData: true,
+		},
+		keepPercent: {
+			dataKey: "keep_percentage",
+				infoHeader: t("Kept"),
+				infoText: t(
+				"Percentage of times the card was kept when presented during mulligan.",
+			),
+				percent: true,
+				sortKey: "keepPercent",
+				text: t("Kept"),
+		},
+		drawnWinrate: {
+			dataKey: "winrate_when_drawn",
+				infoHeader: t("Drawn winrate"),
+				infoText: t(
+				"Average winrate of games where the card was drawn at any point or ended up in the opening hand.",
+			),
+				sortKey: "drawnWinrate",
+				text: t("Drawn WR"),
+				winrateData: true,
+		},
+		playedWinrate: {
+			dataKey: "winrate_when_played",
+				infoHeader: t("Played winrate"),
+				infoText: t(
+				"Average winrate of games where the card was played at any point.",
+			),
+				sortKey: "playedWinrate",
+				text: t("Played WR"),
+				winrateData: true,
+		},
+		turnsInHand: {
+			dataKey: "avg_turns_in_hand",
+				infoHeader: t("Turns held"),
+				infoText: t("Average number of turns the card was held in hand."),
+				sortKey: "turnsInHand",
+				text: t("Turns held"),
+		},
+		turnPlayed: {
+			dataKey: "avg_turn_played_on",
+				infoHeader: t("Turn played"),
+				infoText: t("Average turn the card was played on."),
+				sortKey: "turnPlayed",
+				text: t("Turn played"),
+		},
+		timesPlayedPersonal: {
+			dataKey: "times_played",
+				infoHeader: t("Times played"),
+				infoText: t("Number of times you played the card."),
+				sortKey: "timesPlayed",
+				text: t("Times played"),
+		},
+		damageDone: {
+			dataKey: "damage_done",
+				infoHeader: t("Damage done"),
+				infoText: t(
+				"Total amount of damage the card has dealt. Does not include overkills.",
+			),
+				sortKey: "damageDone",
+				text: t("Damage done"),
+		},
+		healingDone: {
+			dataKey: "healing_done",
+				infoHeader: t("Healing done"),
+				infoText: t(
+				"Total amount of healing the card has done. Does not include overhealing.",
+			),
+				sortKey: "healingDone",
+				text: t("Healing done"),
+		},
+		heroesKilled: {
+			dataKey: "heroes_killed",
+				infoHeader: t("Heroes killed"),
+				infoText: t("Number of heroes the card has killed."),
+				sortKey: "heroesKilled",
+				text: t("Heroes killed"),
+		},
+		minionsKilled: {
+			dataKey: "minions_killed",
+				infoHeader: t("Minions killed"),
+				infoText: t("Number of minions the card has killed."),
+				sortKey: "minionsKilled",
+				text: t("Minions killed"),
+		},
+		totalGames: {
+			dataKey: "total_games",
+				infoHeader: t("Total games"),
+				infoText: t(
+				"Number of games you played with a deck that included the card.",
+			),
+				sortKey: "totalGames",
+				text: t("Total games"),
+		},
+		winrate: {
+			dataKey: "winrate",
+				infoHeader: t("Winrate"),
+				infoText: t("Winrate of decks including the card."),
+				sortKey: "winrate",
+				text: t("Winrate"),
+				winrateData: true,
+		},
+		distinctDecks: {
+			dataKey: "distinct_decks",
+				infoHeader: t("Distinct decks"),
+				infoText: t("Number of distinct decks you included the card in."),
+				sortKey: "distinctDecks",
+				text: t("Distinct decks"),
+		},
+		includedPopularity: {
+			dataKey: "included_popularity",
+				infoHeader: t("Included in % of decks"),
+				infoText: t(
+				"Percentage of decks that include at least one copy of this card.",
+			),
+				percent: true,
+				sortKey: "includedPopularity",
+				text: t("In % of decks"),
+		},
+		includedCount: {
+			dataKey: "included_count",
+				infoHeader: t("Copies in deck"),
+				infoText: t("Average number of copies in a deck."),
+				sortKey: "includedCount",
+				text: t("Copies"),
+		},
+		includedWinrate: {
+			dataKey: "included_winrate",
+				infoHeader: t("Deck winrate"),
+				infoText: t("Average winrate of decks that include this card."),
+				sortKey: "includedWinrate",
+				text: t("Deck winrate"),
+				winrateData: true,
+		},
+		timesPlayedTotal: {
+			dataKey: "times_played",
+				infoHeader: t("Times played"),
+				infoText: t("Number of times the card was played."),
+				prettify: true,
+				sortKey: "timesPlayed",
+				text: t("Times played"),
+		},
+		playedPopularity: {
+			dataKey: "played_popularity",
+				infoHeader: t("% of played cards"),
+				infoText: t("Percentage of all cards played."),
+				percent: true,
+				sortKey: "timesPlayed",
+				text: t("% of played cards"),
+		},
+		prevalence: {
+			dataKey: "prevalence",
+				sortKey: "prevalence",
+				text: t("Prevalence"),
+		},
+	}
 };

--- a/hsreplaynet/static/scripts/src/components/text/PrettyCardClass.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyCardClass.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-i18next";
 import { CardClass } from "../../hearthstone";
 import { getCardClass } from "../../utils/enums";
-import {getCardClassName, toTitleCase} from "../../helpers";
+import { getCardClassName, getHeroClassName, toTitleCase } from "../../helpers";
 import UserData from "../../UserData";
 
 interface Props extends InjectedTranslateProps, InjectedI18nProps {
@@ -24,33 +24,7 @@ class PrettyCardClass extends React.Component<Props> {
 		) {
 			return toTitleCase(getCardClassName(cardClass));
 		}
-
-		switch (cardClass) {
-			case CardClass.DEATHKNIGHT:
-				return t("GLOBAL_CLASS_DEATHKNIGHT");
-			case CardClass.DRUID:
-				return t("GLOBAL_CLASS_DRUID");
-			case CardClass.HUNTER:
-				return t("GLOBAL_CLASS_HUNTER");
-			case CardClass.MAGE:
-				return t("GLOBAL_CLASS_MAGE");
-			case CardClass.PALADIN:
-				return t("GLOBAL_CLASS_PALADIN");
-			case CardClass.PRIEST:
-				return t("GLOBAL_CLASS_PRIEST");
-			case CardClass.ROGUE:
-				return t("GLOBAL_CLASS_ROGUE");
-			case CardClass.SHAMAN:
-				return t("GLOBAL_CLASS_SHAMAN");
-			case CardClass.WARLOCK:
-				return t("GLOBAL_CLASS_WARLOCK");
-			case CardClass.WARRIOR:
-				return t("GLOBAL_CLASS_WARRIOR");
-			case CardClass.NEUTRAL:
-				return t("GLOBAL_CLASS_NEUTRAL");
-		}
-
-		return t("Unknown class");
+		return getHeroClassName(getCardClassName(cardClass), t);
 	}
 }
 

--- a/hsreplaynet/static/scripts/src/components/text/PrettyCardClass.tsx
+++ b/hsreplaynet/static/scripts/src/components/text/PrettyCardClass.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-i18next";
 import { CardClass } from "../../hearthstone";
 import { getCardClass } from "../../utils/enums";
-import { getCardClassName, getHeroClassName } from "../../helpers";
+import {getCardClassName, toTitleCase} from "../../helpers";
 import UserData from "../../UserData";
 
 interface Props extends InjectedTranslateProps, InjectedI18nProps {
@@ -22,7 +22,7 @@ class PrettyCardClass extends React.Component<Props> {
 			!i18n.hasResourceBundle(i18n.language, "hearthstone") ||
 			!UserData.hasFeature("frontend-translations")
 		) {
-			return getHeroClassName(getCardClassName(cardClass));
+			return toTitleCase(getCardClassName(cardClass));
 		}
 
 		switch (cardClass) {

--- a/hsreplaynet/static/scripts/src/entries/replay_detail.tsx
+++ b/hsreplaynet/static/scripts/src/entries/replay_detail.tsx
@@ -20,6 +20,8 @@ const context = JSON.parse(
 );
 UserData.create();
 
+const locale = UserData.getLocale();
+
 // Joust
 const embedder = new JoustEmbedder();
 
@@ -54,12 +56,12 @@ if (endpoint) {
 }
 const shared = {};
 
-embedder.prepare(container);
+embedder.prepare(container, i18n.getFixedT(UserData.getLocale()));
 
 // privacy dropodown
 const targetTmp1 = document.getElementById("replay-infobox-container");
 ReactDOM.render(
-	<I18nextProvider i18n={i18n} initialLanguage={UserData.getLocale()}>
+	<I18nextProvider i18n={i18n} initialLanguage={locale}>
 		<>
 			<h1>{context["format_name"] || "Replay"}</h1>
 
@@ -246,7 +248,7 @@ const renderPlayerInfo = (
 	}
 	const renderPlayerInfoComponent = (cards?) => {
 		ReactDOM.render(
-			<I18nextProvider i18n={i18n} initialLanguage={UserData.getLocale()}>
+			<I18nextProvider i18n={i18n} initialLanguage={locale}>
 				<PlayerInfo
 					gameId={context["shortid"]}
 					playerName={context["player_name"]}

--- a/hsreplaynet/static/scripts/src/entries/replay_embed.tsx
+++ b/hsreplaynet/static/scripts/src/entries/replay_embed.tsx
@@ -1,4 +1,6 @@
 import JoustEmbedder from "../JoustEmbedder";
+import i18n from "../i18n";
+import UserData from "../UserData";
 
 // Joust
 const embedder = new JoustEmbedder();
@@ -21,4 +23,5 @@ if (location.hash) {
 	}
 }
 
-embedder.embed(container);
+UserData.create();
+embedder.embed(container, i18n.getFixedT(UserData.getLocale()));

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -16,6 +16,9 @@ import {
 import { Archetype } from "./utils/api";
 import { getCardClass, getRarity } from "./utils/enums";
 import { CardData as HearthstoneJSONCardData } from "hearthstonejson-client";
+import {
+	TranslationFunction
+} from "react-i18next";
 
 export function staticFile(file: string) {
 	return STATIC_URL + file;
@@ -253,25 +256,27 @@ const classColorScheme: ChartScheme = {
 	},
 };
 
-export const setNames = {
-	core: "Basic",
-	expert1: "Classic",
-	hof: "Hall of Fame",
-	naxx: "Curse of Naxxramas",
-	gvg: "Goblins vs Gnomes",
-	brm: "Blackrock Mountain",
-	tgt: "The Grand Tournament",
-	tb: "Tavern Brawl",
-	loe: "League of Explorers",
-	og: "Whispers of the Old Gods",
-	kara: "One Night in Karazhan",
-	gangs: "Mean Streets of Gadgetzan",
-	ungoro: "Journey to Un'Goro",
-	icecrown: "Knights of the Frozen Throne",
-	lootapalooza: "Kobolds and Catacombs",
-	gilneas: "The Witchwood",
-	taverns_of_time: "Taverns of Time",
-};
+export function getSetNames(t: TranslationFunction) {
+	return {
+		core: t("GLOBAL_CARD_SET_CORE"),
+		expert1: t("GLOBAL_CARD_SET_EXPERT1"),
+		hof: t("GLOBAL_CARD_SET_HOF"),
+		naxx: t("GLOBAL_CARD_SET_NAXX"),
+		gvg: t("GLOBAL_CARD_SET_GVG"),
+		brm: t("GLOBAL_CARD_SET_BRM"),
+		tgt: t("GLOBAL_CARD_SET_TGT"),
+		tb: t("Tavern Brawl"),
+		loe: t("GLOBAL_CARD_SET_LOE"),
+		og: t("GLOBAL_CARD_SET_OG"),
+		kara: t("GLOBAL_CARD_SET_KARA"),
+		gangs: t("GLOBAL_CARD_SET_GANGS"),
+		ungoro: t("GLOBAL_CARD_SET_UNGORO"),
+		icecrown: t("GLOBAL_CARD_SET_ICECROWN"),
+		lootapalooza: t("GLOBAL_CARD_SET_LOOTAPALOOZA"),
+		gilneas: t("GLOBAL_CARD_SET_GILNEAS"),
+		taverns_of_time: t("Taverns of Time"),
+	}
+}
 
 export function isCollectibleCard(card: HearthstoneJSONCardData): boolean {
 	return card.collectible && isPlayableCard(card);
@@ -605,7 +610,33 @@ export function getHeroCardId(cardClass: CardClass | string): string | null {
 	return null;
 }
 
-export function getHeroClassName(cardClass: string): string {
+export function getHeroClassName(cardClass: string, t: TranslationFunction): string {
+	switch(cardClass) {
+		case "DEATHKNIGHT":
+			return t("GLOBAL_CLASS_DEATHKNIGHT");
+		case "DRUID":
+			return t("GLOBAL_CLASS_DRUID");
+		case "HUNTER":
+			return t("GLOBAL_CLASS_HUNTER");
+		case "MAGE":
+			return t("GLOBAL_CLASS_MAGE");
+		case "PALADIN":
+			return t("GLOBAL_CLASS_PALADIN");
+		case "PRIEST":
+			return t("GLOBAL_CLASS_PRIEST");
+		case "ROGUE":
+			return t("GLOBAL_CLASS_ROGUE");
+		case "SHAMAN":
+			return t("GLOBAL_CLASS_SHAMAN");
+		case "WARLOCK":
+			return t("GLOBAL_CLASS_WARLOCK");
+		case "WARRIOR":
+			return t("GLOBAL_CLASS_WARRIOR");
+		case "DREAM":
+			return t("Dream");
+		case "NEUTRAL":
+			return t("GLOBAL_CLASS_NEUTRAL");
+	}
 	return toTitleCase(cardClass);
 }
 
@@ -953,7 +984,7 @@ export function getCardClassName(cardClass: CardClass): string {
 	}
 }
 
-export function getOtherArchetype(archetypeId: number): Archetype {
+export function getOtherArchetype(archetypeId: number, t: TranslationFunction): Archetype {
 	if (archetypeId > 0) {
 		return undefined;
 	}
@@ -966,7 +997,7 @@ export function getOtherArchetype(archetypeId: number): Archetype {
 
 	return {
 		id: archetypeId,
-		name: "Other " + getHeroClassName(className),
+		name: t("Other {cardClass}", {cardClass: getHeroClassName(className, t)}),
 		player_class: -archetypeId,
 		player_class_name: className,
 		url: "",

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -16,9 +16,7 @@ import {
 import { Archetype } from "./utils/api";
 import { getCardClass, getRarity } from "./utils/enums";
 import { CardData as HearthstoneJSONCardData } from "hearthstonejson-client";
-import {
-	TranslationFunction
-} from "react-i18next";
+import { TranslationFunction } from "react-i18next";
 
 export function staticFile(file: string) {
 	return STATIC_URL + file;
@@ -82,7 +80,10 @@ export function getHeroColor(cardClass: CardClass | string): string {
 	}
 }
 
-export function getChartScheme(theme: ChartSchemeType, t: TranslationFunction): ChartScheme {
+export function getChartScheme(
+	theme: ChartSchemeType,
+	t: TranslationFunction,
+): ChartScheme {
 	let scheme: ChartScheme = null;
 	switch (theme) {
 		case "rarity":
@@ -174,10 +175,10 @@ function getRarityScheme(t: TranslationFunction): ChartScheme {
 			stroke: "rgba(255, 128, 0, 0.9)",
 			name: t("GLOBAL_RARITY_LEGENDARY"),
 		},
-	}
+	};
 }
 
-function getCardtypeScheme (t: TranslationFunction): ChartScheme {
+function getCardtypeScheme(t: TranslationFunction): ChartScheme {
 	return {
 		minion: {
 			fill: "rgba(171, 212, 115, 0.5)",
@@ -194,10 +195,10 @@ function getCardtypeScheme (t: TranslationFunction): ChartScheme {
 			stroke: "rgba(196, 30, 59, 0.9)",
 			name: t("GLOBAL_CARDTYPE_WEAPON"),
 		},
-	}
+	};
 }
 
-function getClassColorScheme (t: TranslationFunction): ChartScheme {
+function getClassColorScheme(t: TranslationFunction): ChartScheme {
 	return {
 		all: {
 			stroke: "rgba(169, 169, 169, 1)",
@@ -217,7 +218,7 @@ function getClassColorScheme (t: TranslationFunction): ChartScheme {
 		hunter: {
 			stroke: "rgba(171, 212, 114, 1)",
 			fill: "rgba(171, 212, 114, 0.7)",
-			name: getHeroClassName("HUNTER", t)
+			name: getHeroClassName("HUNTER", t),
 		},
 		mage: {
 			stroke: "rgba(105, 204, 240, 1)",
@@ -259,11 +260,11 @@ function getClassColorScheme (t: TranslationFunction): ChartScheme {
 			fill: "rgba(122, 122, 122, 0.7)",
 			name: t("Other"),
 		},
-	}
+	};
 }
 
 export function getSetName(set: string, t: TranslationFunction): string {
-	switch(set) {
+	switch (set) {
 		case "core":
 			return t("GLOBAL_CARD_SET_CORE");
 		case "expert1":
@@ -634,8 +635,11 @@ export function getHeroCardId(cardClass: CardClass | string): string | null {
 	return null;
 }
 
-export function getHeroClassName(cardClass: string, t: TranslationFunction): string {
-	switch(cardClass) {
+export function getHeroClassName(
+	cardClass: string,
+	t: TranslationFunction,
+): string {
+	switch (cardClass) {
 		case "DEATHKNIGHT":
 			return t("GLOBAL_CLASS_DEATHKNIGHT");
 		case "DRUID":
@@ -1008,7 +1012,10 @@ export function getCardClassName(cardClass: CardClass): string {
 	}
 }
 
-export function getOtherArchetype(archetypeId: number, t: TranslationFunction): Archetype {
+export function getOtherArchetype(
+	archetypeId: number,
+	t: TranslationFunction,
+): Archetype {
 	if (archetypeId > 0) {
 		return undefined;
 	}
@@ -1021,7 +1028,9 @@ export function getOtherArchetype(archetypeId: number, t: TranslationFunction): 
 
 	return {
 		id: archetypeId,
-		name: t("Other {cardClass}", {cardClass: getHeroClassName(className, t)}),
+		name: t("Other {cardClass}", {
+			cardClass: getHeroClassName(className, t),
+		}),
 		player_class: -archetypeId,
 		player_class_name: className,
 		url: "",

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -262,25 +262,42 @@ function getClassColorScheme (t: TranslationFunction): ChartScheme {
 	}
 }
 
-export function getSetNames(t: TranslationFunction) {
-	return {
-		core: t("GLOBAL_CARD_SET_CORE"),
-		expert1: t("GLOBAL_CARD_SET_EXPERT1"),
-		hof: t("GLOBAL_CARD_SET_HOF"),
-		naxx: t("GLOBAL_CARD_SET_NAXX"),
-		gvg: t("GLOBAL_CARD_SET_GVG"),
-		brm: t("GLOBAL_CARD_SET_BRM"),
-		tgt: t("GLOBAL_CARD_SET_TGT"),
-		tb: t("Tavern Brawl"),
-		loe: t("GLOBAL_CARD_SET_LOE"),
-		og: t("GLOBAL_CARD_SET_OG"),
-		kara: t("GLOBAL_CARD_SET_KARA"),
-		gangs: t("GLOBAL_CARD_SET_GANGS"),
-		ungoro: t("GLOBAL_CARD_SET_UNGORO"),
-		icecrown: t("GLOBAL_CARD_SET_ICECROWN"),
-		lootapalooza: t("GLOBAL_CARD_SET_LOOTAPALOOZA"),
-		gilneas: t("GLOBAL_CARD_SET_GILNEAS"),
-		taverns_of_time: t("Taverns of Time"),
+export function getSetName(set: string, t: TranslationFunction) {
+	switch(set) {
+		case "core":
+			return t("GLOBAL_CARD_SET_CORE");
+		case "expert1":
+			return t("GLOBAL_CARD_SET_EXPERT1");
+		case "hof":
+			return t("GLOBAL_CARD_SET_HOF");
+		case "naxx":
+			return t("GLOBAL_CARD_SET_NAXX");
+		case "gvg":
+			return t("GLOBAL_CARD_SET_GVG");
+		case "brm":
+			return t("GLOBAL_CARD_SET_BRM");
+		case "tgt":
+			return t("GLOBAL_CARD_SET_TGT");
+		case "tb":
+			return t("GLOBAL_TAVERN_BRAWL");
+		case "loe":
+			return t("GLOBAL_CARD_SET_LOE");
+		case "og":
+			return t("GLOBAL_CARD_SET_OG");
+		case "kara":
+			return t("GLOBAL_CARD_SET_KARA");
+		case "gangs":
+			return t("GLOBAL_CARD_SET_GANGS");
+		case "ungoro":
+			return t("GLOBAL_CARD_SET_UNGORO");
+		case "icecrown":
+			return t("GLOBAL_CARD_SET_ICECROWN");
+		case "lootapalooza":
+			return t("GLOBAL_CARD_SET_LOOTAPALOOZA");
+		case "gilneas":
+			return t("GLOBAL_CARD_SET_GILNEAS");
+		case "taverns_of_time":
+			return t("Taverns of Time");
 	}
 }
 

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -299,6 +299,7 @@ export function getSetName(set: string, t: TranslationFunction): string {
 		case "taverns_of_time":
 			return t("Taverns of Time");
 	}
+	return t("Unknown Set");
 }
 
 export function isCollectibleCard(card: HearthstoneJSONCardData): boolean {

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -82,21 +82,21 @@ export function getHeroColor(cardClass: CardClass | string): string {
 	}
 }
 
-export function getChartScheme(theme: ChartSchemeType): ChartScheme {
+export function getChartScheme(theme: ChartSchemeType, t: TranslationFunction): ChartScheme {
 	let scheme: ChartScheme = null;
 	switch (theme) {
 		case "rarity":
-			scheme = rarityScheme;
+			scheme = getRarityScheme(t);
 			break;
 
 		case "cardtype":
-			scheme = cardtypeScheme;
+			scheme = getCardtypeScheme(t);
 			break;
 		case "cost":
 			scheme = costScheme;
 			break;
 		case "class":
-			scheme = classColorScheme;
+			scheme = getClassColorScheme(t);
 			break;
 	}
 	return Object.assign(
@@ -147,114 +147,120 @@ const costScheme: ChartScheme = {
 	},
 };
 
-const rarityScheme: ChartScheme = {
-	free: {
-		fill: "rgba(211, 211, 211, 0.5)",
-		stroke: "rgba(211, 211, 211, 0.9)",
-		name: "Free",
-	},
-	common: {
-		fill: "rgba(169, 169, 169, 0.5)",
-		stroke: "rgba(169, 169, 169, 0.9)",
-		name: "Common",
-	},
-	rare: {
-		fill: "rgba(0, 112, 221, 0.5)",
-		stroke: "rgba(0, 112, 221, 0.9)",
-		name: "Rare",
-	},
-	epic: {
-		fill: "rgba(163, 53, 238, 0.5)",
-		stroke: "rgba(163, 53, 238, 0.9)",
-		name: "Epic",
-	},
-	legendary: {
-		fill: "rgba(255, 128, 0, 0.5)",
-		stroke: "rgba(255, 128, 0, 0.9)",
-		name: "Legendary",
-	},
-};
+function getRarityScheme(t: TranslationFunction): ChartScheme {
+	return {
+		free: {
+			fill: "rgba(211, 211, 211, 0.5)",
+			stroke: "rgba(211, 211, 211, 0.9)",
+			name: t("GLOBAL_RARITY_FREE"),
+		},
+		common: {
+			fill: "rgba(169, 169, 169, 0.5)",
+			stroke: "rgba(169, 169, 169, 0.9)",
+			name: t("GLOBAL_RARITY_COMMON"),
+		},
+		rare: {
+			fill: "rgba(0, 112, 221, 0.5)",
+			stroke: "rgba(0, 112, 221, 0.9)",
+			name: t("GLOBAL_RARITY_RARE"),
+		},
+		epic: {
+			fill: "rgba(163, 53, 238, 0.5)",
+			stroke: "rgba(163, 53, 238, 0.9)",
+			name: t("GLOBAL_RARITY_EPIC"),
+		},
+		legendary: {
+			fill: "rgba(255, 128, 0, 0.5)",
+			stroke: "rgba(255, 128, 0, 0.9)",
+			name: t("GLOBAL_RARITY_LEGENDARY"),
+		},
+	}
+}
 
-const cardtypeScheme: ChartScheme = {
-	minion: {
-		fill: "rgba(171, 212, 115, 0.5)",
-		stroke: "rgba(171, 212, 115, 0.9)",
-		name: "Minion",
-	},
-	spell: {
-		fill: "rgba(0, 112, 222, 0.5)",
-		stroke: "rgba(0, 112, 222, 0.9)",
-		name: "Spell",
-	},
-	weapon: {
-		fill: "rgba(196, 30, 59, 0.5)",
-		stroke: "rgba(196, 30, 59, 0.9)",
-		name: "Weapon",
-	},
-};
+function getCardtypeScheme (t: TranslationFunction): ChartScheme {
+	return {
+		minion: {
+			fill: "rgba(171, 212, 115, 0.5)",
+			stroke: "rgba(171, 212, 115, 0.9)",
+			name: t("GLOBAL_CARDTYPE_MINION"),
+		},
+		spell: {
+			fill: "rgba(0, 112, 222, 0.5)",
+			stroke: "rgba(0, 112, 222, 0.9)",
+			name: t("GLOBAL_CARDTYPE_SPELL"),
+		},
+		weapon: {
+			fill: "rgba(196, 30, 59, 0.5)",
+			stroke: "rgba(196, 30, 59, 0.9)",
+			name: t("GLOBAL_CARDTYPE_WEAPON"),
+		},
+	}
+}
 
-const classColorScheme: ChartScheme = {
-	all: {
-		stroke: "rgba(169, 169, 169, 1)",
-		fill: "rgba(169, 169, 169, 0.7)",
-		name: "All",
-	},
-	neutral: {
-		stroke: "rgba(169, 169, 169, 1)",
-		fill: "rgba(169, 169, 169, 0.7)",
-		name: "Neutral",
-	},
-	druid: {
-		stroke: "rgba(255, 125, 10, 1)",
-		fill: "rgba(255, 125, 10, 0.7)",
-		name: "Druid",
-	},
-	hunter: {
-		stroke: "rgba(171, 212, 114, 1)",
-		fill: "rgba(171, 212, 114, 0.7)",
-		name: "Hunter",
-	},
-	mage: {
-		stroke: "rgba(105, 204, 240, 1)",
-		fill: "rgba(105, 204, 240, 0.7)",
-		name: "Mage",
-	},
-	paladin: {
-		stroke: "rgba(245, 140, 186, 1)",
-		fill: "rgba(245, 140, 186, 0.7)",
-		name: "Paladin",
-	},
-	priest: {
-		stroke: "rgba(210, 210, 210, 1)",
-		fill: "rgba(210, 210, 210, 0.7)",
-		name: "Priest",
-	},
-	rogue: {
-		stroke: "rgba(255, 217, 26, 1)",
-		fill: "rgba(255, 240, 26, 0.7)",
-		name: "Rogue",
-	},
-	shaman: {
-		stroke: "rgba(0, 122, 222, 1)",
-		fill: "rgba(0, 122, 222, 0.7)",
-		name: "Shaman",
-	},
-	warlock: {
-		stroke: "rgba(148, 130, 201, 1)",
-		fill: "rgba(148, 130, 201, 0.7)",
-		name: "Warlock",
-	},
-	warrior: {
-		stroke: "rgba(199, 156, 110, 1)",
-		fill: "rgba(199, 156, 110, 0.7)",
-		name: "Warrior",
-	},
-	other: {
-		stroke: "rgba(122, 122, 122, 1)",
-		fill: "rgba(122, 122, 122, 0.7)",
-		name: "Other",
-	},
-};
+function getClassColorScheme (t: TranslationFunction): ChartScheme {
+	return {
+		all: {
+			stroke: "rgba(169, 169, 169, 1)",
+			fill: "rgba(169, 169, 169, 0.7)",
+			name: t("All"),
+		},
+		neutral: {
+			stroke: "rgba(169, 169, 169, 1)",
+			fill: "rgba(169, 169, 169, 0.7)",
+			name: t("GLOBAL_CLASS_NEUTRAL"),
+		},
+		druid: {
+			stroke: "rgba(255, 125, 10, 1)",
+			fill: "rgba(255, 125, 10, 0.7)",
+			name: t("GLOBAL_CLASS_DRUID"),
+		},
+		hunter: {
+			stroke: "rgba(171, 212, 114, 1)",
+			fill: "rgba(171, 212, 114, 0.7)",
+			name: t("GLOBAL_CLASS_HUNTER"),
+		},
+		mage: {
+			stroke: "rgba(105, 204, 240, 1)",
+			fill: "rgba(105, 204, 240, 0.7)",
+			name: t("GLOBAL_CLASS_MAGE"),
+		},
+		paladin: {
+			stroke: "rgba(245, 140, 186, 1)",
+			fill: "rgba(245, 140, 186, 0.7)",
+			name: t("GLOBAL_CLASS_PALADIN"),
+		},
+		priest: {
+			stroke: "rgba(210, 210, 210, 1)",
+			fill: "rgba(210, 210, 210, 0.7)",
+			name: t("GLOBAL_CLASS_PRIEST"),
+		},
+		rogue: {
+			stroke: "rgba(255, 217, 26, 1)",
+			fill: "rgba(255, 240, 26, 0.7)",
+			name: t("GLOBAL_CLASS_ROGUE"),
+		},
+		shaman: {
+			stroke: "rgba(0, 122, 222, 1)",
+			fill: "rgba(0, 122, 222, 0.7)",
+			name: t("GLOBAL_CLASS_SHAMAN"),
+		},
+		warlock: {
+			stroke: "rgba(148, 130, 201, 1)",
+			fill: "rgba(148, 130, 201, 0.7)",
+			name: t("GLOBAL_CLASS_WARLOCK"),
+		},
+		warrior: {
+			stroke: "rgba(199, 156, 110, 1)",
+			fill: "rgba(199, 156, 110, 0.7)",
+			name: t("GLOBAL_CLASS_WARRIOR"),
+		},
+		other: {
+			stroke: "rgba(122, 122, 122, 1)",
+			fill: "rgba(122, 122, 122, 0.7)",
+			name: t("Other"),
+		},
+	}
+}
 
 export function getSetNames(t: TranslationFunction) {
 	return {

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -207,52 +207,52 @@ function getClassColorScheme (t: TranslationFunction): ChartScheme {
 		neutral: {
 			stroke: "rgba(169, 169, 169, 1)",
 			fill: "rgba(169, 169, 169, 0.7)",
-			name: t("GLOBAL_CLASS_NEUTRAL"),
+			name: getHeroClassName("NEUTRAL", t),
 		},
 		druid: {
 			stroke: "rgba(255, 125, 10, 1)",
 			fill: "rgba(255, 125, 10, 0.7)",
-			name: t("GLOBAL_CLASS_DRUID"),
+			name: getHeroClassName("DRUID", t),
 		},
 		hunter: {
 			stroke: "rgba(171, 212, 114, 1)",
 			fill: "rgba(171, 212, 114, 0.7)",
-			name: t("GLOBAL_CLASS_HUNTER"),
+			name: getHeroClassName("HUNTER", t)
 		},
 		mage: {
 			stroke: "rgba(105, 204, 240, 1)",
 			fill: "rgba(105, 204, 240, 0.7)",
-			name: t("GLOBAL_CLASS_MAGE"),
+			name: getHeroClassName("MAGE", t),
 		},
 		paladin: {
 			stroke: "rgba(245, 140, 186, 1)",
 			fill: "rgba(245, 140, 186, 0.7)",
-			name: t("GLOBAL_CLASS_PALADIN"),
+			name: getHeroClassName("PALADIN", t),
 		},
 		priest: {
 			stroke: "rgba(210, 210, 210, 1)",
 			fill: "rgba(210, 210, 210, 0.7)",
-			name: t("GLOBAL_CLASS_PRIEST"),
+			name: getHeroClassName("PRIEST", t),
 		},
 		rogue: {
 			stroke: "rgba(255, 217, 26, 1)",
 			fill: "rgba(255, 240, 26, 0.7)",
-			name: t("GLOBAL_CLASS_ROGUE"),
+			name: getHeroClassName("ROGUE", t),
 		},
 		shaman: {
 			stroke: "rgba(0, 122, 222, 1)",
 			fill: "rgba(0, 122, 222, 0.7)",
-			name: t("GLOBAL_CLASS_SHAMAN"),
+			name: getHeroClassName("SHAMAN", t),
 		},
 		warlock: {
 			stroke: "rgba(148, 130, 201, 1)",
 			fill: "rgba(148, 130, 201, 0.7)",
-			name: t("GLOBAL_CLASS_WARLOCK"),
+			name: getHeroClassName("WARLOCK", t),
 		},
 		warrior: {
 			stroke: "rgba(199, 156, 110, 1)",
 			fill: "rgba(199, 156, 110, 0.7)",
-			name: t("GLOBAL_CLASS_WARRIOR"),
+			name: getHeroClassName("WARRIOR", t),
 		},
 		other: {
 			stroke: "rgba(122, 122, 122, 1)",

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -153,27 +153,27 @@ function getRarityScheme(t: TranslationFunction): ChartScheme {
 		free: {
 			fill: "rgba(211, 211, 211, 0.5)",
 			stroke: "rgba(211, 211, 211, 0.9)",
-			name: t("GLOBAL_RARITY_FREE"),
+			name: t("GLOBAL_RARITY_FREE", { ns: "hearthstone" }),
 		},
 		common: {
 			fill: "rgba(169, 169, 169, 0.5)",
 			stroke: "rgba(169, 169, 169, 0.9)",
-			name: t("GLOBAL_RARITY_COMMON"),
+			name: t("GLOBAL_RARITY_COMMON", { ns: "hearthstone" }),
 		},
 		rare: {
 			fill: "rgba(0, 112, 221, 0.5)",
 			stroke: "rgba(0, 112, 221, 0.9)",
-			name: t("GLOBAL_RARITY_RARE"),
+			name: t("GLOBAL_RARITY_RARE", { ns: "hearthstone" }),
 		},
 		epic: {
 			fill: "rgba(163, 53, 238, 0.5)",
 			stroke: "rgba(163, 53, 238, 0.9)",
-			name: t("GLOBAL_RARITY_EPIC"),
+			name: t("GLOBAL_RARITY_EPIC", { ns: "hearthstone" }),
 		},
 		legendary: {
 			fill: "rgba(255, 128, 0, 0.5)",
 			stroke: "rgba(255, 128, 0, 0.9)",
-			name: t("GLOBAL_RARITY_LEGENDARY"),
+			name: t("GLOBAL_RARITY_LEGENDARY", { ns: "hearthstone" }),
 		},
 	};
 }
@@ -183,17 +183,17 @@ function getCardtypeScheme(t: TranslationFunction): ChartScheme {
 		minion: {
 			fill: "rgba(171, 212, 115, 0.5)",
 			stroke: "rgba(171, 212, 115, 0.9)",
-			name: t("GLOBAL_CARDTYPE_MINION"),
+			name: t("GLOBAL_CARDTYPE_MINION", { ns: "hearthstone" }),
 		},
 		spell: {
 			fill: "rgba(0, 112, 222, 0.5)",
 			stroke: "rgba(0, 112, 222, 0.9)",
-			name: t("GLOBAL_CARDTYPE_SPELL"),
+			name: t("GLOBAL_CARDTYPE_SPELL", { ns: "hearthstone" }),
 		},
 		weapon: {
 			fill: "rgba(196, 30, 59, 0.5)",
 			stroke: "rgba(196, 30, 59, 0.9)",
-			name: t("GLOBAL_CARDTYPE_WEAPON"),
+			name: t("GLOBAL_CARDTYPE_WEAPON", { ns: "hearthstone" }),
 		},
 	};
 }
@@ -266,37 +266,37 @@ function getClassColorScheme(t: TranslationFunction): ChartScheme {
 export function getSetName(set: string, t: TranslationFunction): string {
 	switch (set) {
 		case "core":
-			return t("GLOBAL_CARD_SET_CORE");
+			return t("GLOBAL_CARD_SET_CORE", { ns: "hearthstone" });
 		case "expert1":
-			return t("GLOBAL_CARD_SET_EXPERT1");
+			return t("GLOBAL_CARD_SET_EXPERT1", { ns: "hearthstone" });
 		case "hof":
-			return t("GLOBAL_CARD_SET_HOF");
+			return t("GLOBAL_CARD_SET_HOF", { ns: "hearthstone" });
 		case "naxx":
-			return t("GLOBAL_CARD_SET_NAXX");
+			return t("GLOBAL_CARD_SET_NAXX", { ns: "hearthstone" });
 		case "gvg":
-			return t("GLOBAL_CARD_SET_GVG");
+			return t("GLOBAL_CARD_SET_GVG", { ns: "hearthstone" });
 		case "brm":
-			return t("GLOBAL_CARD_SET_BRM");
+			return t("GLOBAL_CARD_SET_BRM", { ns: "hearthstone" });
 		case "tgt":
-			return t("GLOBAL_CARD_SET_TGT");
+			return t("GLOBAL_CARD_SET_TGT", { ns: "hearthstone" });
 		case "tb":
-			return t("GLOBAL_TAVERN_BRAWL");
+			return t("GLOBAL_TAVERN_BRAWL", { ns: "hearthstone" });
 		case "loe":
-			return t("GLOBAL_CARD_SET_LOE");
+			return t("GLOBAL_CARD_SET_LOE", { ns: "hearthstone" });
 		case "og":
-			return t("GLOBAL_CARD_SET_OG");
+			return t("GLOBAL_CARD_SET_OG", { ns: "hearthstone" });
 		case "kara":
-			return t("GLOBAL_CARD_SET_KARA");
+			return t("GLOBAL_CARD_SET_KARA", { ns: "hearthstone" });
 		case "gangs":
-			return t("GLOBAL_CARD_SET_GANGS");
+			return t("GLOBAL_CARD_SET_GANGS", { ns: "hearthstone" });
 		case "ungoro":
-			return t("GLOBAL_CARD_SET_UNGORO");
+			return t("GLOBAL_CARD_SET_UNGORO", { ns: "hearthstone" });
 		case "icecrown":
-			return t("GLOBAL_CARD_SET_ICECROWN");
+			return t("GLOBAL_CARD_SET_ICECROWN", { ns: "hearthstone" });
 		case "lootapalooza":
-			return t("GLOBAL_CARD_SET_LOOTAPALOOZA");
+			return t("GLOBAL_CARD_SET_LOOTAPALOOZA", { ns: "hearthstone" });
 		case "gilneas":
-			return t("GLOBAL_CARD_SET_GILNEAS");
+			return t("GLOBAL_CARD_SET_GILNEAS", { ns: "hearthstone" });
 		case "taverns_of_time":
 			return t("Taverns of Time");
 	}
@@ -641,29 +641,29 @@ export function getHeroClassName(
 ): string {
 	switch (cardClass) {
 		case "DEATHKNIGHT":
-			return t("GLOBAL_CLASS_DEATHKNIGHT");
+			return t("GLOBAL_CLASS_DEATHKNIGHT", { ns: "hearthstone" });
 		case "DRUID":
-			return t("GLOBAL_CLASS_DRUID");
+			return t("GLOBAL_CLASS_DRUID", { ns: "hearthstone" });
 		case "HUNTER":
-			return t("GLOBAL_CLASS_HUNTER");
+			return t("GLOBAL_CLASS_HUNTER", { ns: "hearthstone" });
 		case "MAGE":
-			return t("GLOBAL_CLASS_MAGE");
+			return t("GLOBAL_CLASS_MAGE", { ns: "hearthstone" });
 		case "PALADIN":
-			return t("GLOBAL_CLASS_PALADIN");
+			return t("GLOBAL_CLASS_PALADIN", { ns: "hearthstone" });
 		case "PRIEST":
-			return t("GLOBAL_CLASS_PRIEST");
+			return t("GLOBAL_CLASS_PRIEST", { ns: "hearthstone" });
 		case "ROGUE":
-			return t("GLOBAL_CLASS_ROGUE");
+			return t("GLOBAL_CLASS_ROGUE", { ns: "hearthstone" });
 		case "SHAMAN":
-			return t("GLOBAL_CLASS_SHAMAN");
+			return t("GLOBAL_CLASS_SHAMAN", { ns: "hearthstone" });
 		case "WARLOCK":
-			return t("GLOBAL_CLASS_WARLOCK");
+			return t("GLOBAL_CLASS_WARLOCK", { ns: "hearthstone" });
 		case "WARRIOR":
-			return t("GLOBAL_CLASS_WARRIOR");
+			return t("GLOBAL_CLASS_WARRIOR", { ns: "hearthstone" });
 		case "DREAM":
 			return t("Dream");
 		case "NEUTRAL":
-			return t("GLOBAL_CLASS_NEUTRAL");
+			return t("GLOBAL_CLASS_NEUTRAL", { ns: "hearthstone" });
 	}
 	return toTitleCase(cardClass);
 }

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -262,7 +262,7 @@ function getClassColorScheme (t: TranslationFunction): ChartScheme {
 	}
 }
 
-export function getSetName(set: string, t: TranslationFunction) {
+export function getSetName(set: string, t: TranslationFunction): string {
 	switch(set) {
 		case "core":
 			return t("GLOBAL_CARD_SET_CORE");

--- a/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
@@ -436,7 +436,7 @@ class CardDetail extends React.Component<Props, State> {
 												<CardDetailPieChart
 													removeEmpty
 													scheme={getChartScheme(
-														"class",
+														"class", t
 													)}
 													sortByValue
 													groupSparseData

--- a/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/CardDetail.tsx
@@ -436,7 +436,8 @@ class CardDetail extends React.Component<Props, State> {
 												<CardDetailPieChart
 													removeEmpty
 													scheme={getChartScheme(
-														"class", t
+														"class",
+														t,
 													)}
 													sortByValue
 													groupSparseData

--- a/hsreplaynet/static/scripts/src/pages/Cards.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Cards.tsx
@@ -21,12 +21,12 @@ import { RankRange, TimeRange } from "../filters";
 import {
 	cardSorting,
 	cleanText,
+	getSetNames,
 	image,
 	isArenaOnlyCard,
 	isCollectibleCard,
 	isPlayableCard,
 	isWildSet,
-	setNames,
 	slangToCardId,
 	toTitleCase,
 } from "../helpers";
@@ -1359,7 +1359,7 @@ class Cards extends React.Component<Props, State> {
 		}
 		const getText = (item: string) => {
 			if (key === "set") {
-				return setNames[item.toLowerCase()];
+				return getSetNames(this.props.t)[item.toLowerCase()];
 			} else if (key === "mechanics") {
 				return item
 					.split("_")

--- a/hsreplaynet/static/scripts/src/pages/Cards.tsx
+++ b/hsreplaynet/static/scripts/src/pages/Cards.tsx
@@ -21,7 +21,7 @@ import { RankRange, TimeRange } from "../filters";
 import {
 	cardSorting,
 	cleanText,
-	getSetNames,
+	getSetName,
 	image,
 	isArenaOnlyCard,
 	isCollectibleCard,
@@ -1359,7 +1359,7 @@ class Cards extends React.Component<Props, State> {
 		}
 		const getText = (item: string) => {
 			if (key === "set") {
-				return getSetNames(this.props.t)[item.toLowerCase()];
+				return getSetName(item.toLowerCase(), this.props.t);
 			} else if (key === "mechanics") {
 				return item
 					.split("_")

--- a/hsreplaynet/static/scripts/src/pages/DeckDetail.tsx
+++ b/hsreplaynet/static/scripts/src/pages/DeckDetail.tsx
@@ -532,10 +532,9 @@ class DeckDetail extends React.Component<Props, State> {
 
 		const { deckName, deckClass } = this.props;
 
-		// FIXME: i18n
 		const copyDeckName = deckName
 			? deckName.replace(/ Deck$/, "")
-			: getHeroClassName(this.props.deckClass);
+			: getHeroClassName(this.props.deckClass, t);
 
 		return (
 			<div className="deck-detail-container">


### PR DESCRIPTION
## List of all js/ts files
Relevant files were identified via `find -follow | grep '[^(\.d)]\.[tj]s$'`

File|Translations
---|---
./static/scripts/src/global.d.ts|-
./static/scripts/src/extractors.ts|-
./static/scripts/src/JoustEmbedder.ts|Joust loading error - **NOT IMPLEMENTED**
./static/scripts/src/TourManager.ts|Buttons
./static/scripts/src/GameFilters.ts|-
./static/scripts/src/CardData.ts|-
./static/scripts/src/utils/account.ts|-
./static/scripts/src/utils/collection.ts|-
./static/scripts/src/utils/enums.ts|-
./static/scripts/src/contants.ts|-
./static/scripts/src/entries/export-react.ts|-
./static/scripts/src/entries/polyfills.ts|-
./static/scripts/src/UserData.ts|-
./static/scripts/src/components/tables/cardtable/RowDataGenerator.ts|-
./static/scripts/src/components/tables/cardtable/CardTableColumns.ts|Fixed stub t() call
./static/scripts/src/i18n.ts|-
./static/scripts/src/RavenWatcher.ts|-
./static/scripts/src/metrics/InfluxMetricsBackend.ts|-
./static/scripts/src/metrics/MetricsBackend.d.ts|-
./static/scripts/src/metrics/GoogleAnalytics.ts|-
./static/scripts/src/metrics/BatchingMiddleware.ts|-
./static/scripts/src/metrics/MetricsReporter.ts|-
./static/scripts/src/DataManager.ts|-
./static/scripts/src/helpers.ts|Set names, CardClass names, "Other" archetype, ChartScheme names
./static/scripts/src/Settings.ts|-
./templates/joust_include.js|-
./templates/footerjs.js|-

## locale/en/frontend.json diff
```diff
diff --git a/en/frontend.json b/en/frontend.json
index 74823c8..8c08517 100644
--- a/en/frontend.json
+++ b/en/frontend.json

diff --git a/en/frontend.json b/en/frontend.json
index 74823c8..41968f5 100644
--- a/en/frontend.json
+++ b/en/frontend.json
@@ -23,6 +23,7 @@
   "Blizzard China (CN)…": "Blizzard China (CN)…",
   "Debug": "Debug",
   "Sign in with password…": "Sign in with password…",
+  "Other {cardClass}": "Other {cardClass}",
   "Not enough games for meaningful matchup data available.": "Not enough games for meaningful matchup data available.",
   "Core cards": "Core cards",
   "Popular cards": "Popular cards",
@@ -375,6 +376,9 @@
   "Previous season": "Previous season",
   "Latest expansion": "Latest expansion",
   "Latest patch": "Latest patch",
+  "All": "All",
+  "Taverns of Time": "Taverns of Time",
+  "Dream": "Dream",
   "My financial situation has changed": "My financial situation has changed",
   "I prefer to manually renew my subscriptions": "I prefer to manually renew my subscriptions",
   "Not enough support for Wild": "Not enough support for Wild",
@@ -755,5 +759,6 @@
   "Your deck tracker is too old!": "Your deck tracker is too old!",
   "We no longer support uploads from the version of Hearthstone you are using. If you are already on the latest version, please contact us for assistance.": "We no longer support uploads from the version of Hearthstone you are using. If you are already on the latest version, please contact us for assistance.",
   "Your replay is still processing. Check back soon!": "Your replay is still processing. Check back soon!",
-  "Something went wrong generating this replay. We're on it.": "Something went wrong generating this replay. We're on it."
+  "Something went wrong generating this replay. We're on it.": "Something went wrong generating this replay. We're on it.",
+  "Done": "Done"

```
## Remaining work
- Is there anything obvious I missed?
- I'm unsure how to proceed with `JoustEmbedder`. `embed()` is called from `replay_embed`, which does not have any React context either. Suggestions?