### PR TITLE
Localize number formatting

### DIFF
--- a/hsreplaynet/static/scripts/src/components/CardRankingTableRow.tsx
+++ b/hsreplaynet/static/scripts/src/components/CardRankingTableRow.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import CardTile from "./CardTile";
-import { winrateData } from "../helpers";
+import { toDynamicFixed, winrateData } from "../helpers";
 import { InjectedTranslateProps, translate } from "react-i18next";
+import { formatNumber } from "../i18n";
 
 interface Props extends InjectedTranslateProps {
 	card: any;
@@ -36,7 +37,7 @@ class CardRankingTableRow extends React.Component<Props> {
 			const wrData = winrateData(50, this.props.winrate, 2);
 			winrateCell = (
 				<td style={{ color: wrData.color }}>
-					{this.props.winrate + "%"}
+					{formatNumber(this.props.winrate, 1) + "%"}
 				</td>
 			);
 		}
@@ -56,12 +57,7 @@ class CardRankingTableRow extends React.Component<Props> {
 	}
 
 	getPopularity() {
-		const digits =
-			Math.min(
-				Math.max(0, Math.floor(Math.log10(1 / this.props.popularity))),
-				2,
-			) + 2;
-		return this.props.popularity.toFixed(digits) + "%";
+		return toDynamicFixed(this.props.popularity, 1) + "%";
 	}
 }
 

--- a/hsreplaynet/static/scripts/src/components/ClassMatchup.tsx
+++ b/hsreplaynet/static/scripts/src/components/ClassMatchup.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { getArchetypeUrl, winrateData } from "../helpers";
 import { getCardClass } from "../utils/enums";
 import PrettyCardClass from "./text/PrettyCardClass";
+import { formatNumber } from "../i18n";
 
 export interface ArchetypeData {
 	id: string;
@@ -45,7 +46,7 @@ export default class ClassMatchup extends React.Component<Props> {
 					</span>
 					<span className="pull-right">
 						{this.props.totalWinrate &&
-							`${this.props.totalWinrate.toFixed(2)}%`}
+							`${formatNumber(this.props.totalWinrate, 2)}%`}
 					</span>
 				</div>
 				{archetypes}
@@ -61,7 +62,7 @@ export default class ClassMatchup extends React.Component<Props> {
 				style={{ color: wrData.color }}
 			>
 				{wrData.tendencyStr}
-				{winrate.toFixed(2) + "%"}
+				{formatNumber(winrate, 2) + "%"}
 			</span>
 		);
 	}

--- a/hsreplaynet/static/scripts/src/components/DeckTile.tsx
+++ b/hsreplaynet/static/scripts/src/components/DeckTile.tsx
@@ -299,10 +299,10 @@ class DeckTile extends React.Component<Props> {
 							>
 								<span className="glyphicon glyphicon-time" />
 								{/* FIXME i18n (use date-fns) */}
-								{" " +
-									`${(this.props.duration / 60).toFixed(
-										1,
-									)} min`}
+								{` ${formatNumber(
+									this.props.duration / 60,
+									1,
+								)} min`}
 							</div>
 						</div>
 						<div className="col-lg-1 hidden-md hidden-sm hidden-xs">

--- a/hsreplaynet/static/scripts/src/components/DeckTile.tsx
+++ b/hsreplaynet/static/scripts/src/components/DeckTile.tsx
@@ -21,6 +21,7 @@ import DataInjector from "./DataInjector";
 import ManaCurve from "./ManaCurve";
 import Tooltip from "./Tooltip";
 import SemanticAge from "./text/SemanticAge";
+import { formatNumber } from "../i18n";
 
 interface ExternalProps extends DeckObj, InjectedTranslateProps {
 	compareWith?: CardObj[];
@@ -283,7 +284,7 @@ class DeckTile extends React.Component<Props> {
 						</div>
 						<div className="col-lg-1 col-md-1 col-sm-1 col-xs-3">
 							<span className="win-rate">
-								{(+this.props.winrate).toFixed(1)}%
+								{formatNumber(+this.props.winrate, 1)}%
 							</span>
 						</div>
 						<div className="col-lg-1 col-md-1 col-sm-1 col-xs-3">

--- a/hsreplaynet/static/scripts/src/components/Distribution.tsx
+++ b/hsreplaynet/static/scripts/src/components/Distribution.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import _ from "lodash";
 import { SelectableProps } from "../interfaces";
+import { formatNumber } from "../i18n";
 
 interface Props extends SelectableProps {
 	distributions: NumberDistribution;
@@ -53,7 +54,7 @@ export default class Distribution extends React.Component<Props> {
 				>
 					<th>{++count}</th>
 					<th>{key}</th>
-					<td>{(value * 100).toFixed(2)}%</td>
+					<td>{formatNumber(value * 100, 2)}%</td>
 				</tr>
 			);
 		});

--- a/hsreplaynet/static/scripts/src/components/StreamThumbnail.tsx
+++ b/hsreplaynet/static/scripts/src/components/StreamThumbnail.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { commaSeparate } from "../helpers";
 import { TwitchStreamPromotionEvents } from "../metrics/GoogleAnalytics";
 import { BnetGameType } from "../hearthstone";
 import RankIcon from "./RankIcon";
 import { InjectedTranslateProps, translate } from "react-i18next";
+import { formatNumber } from "../i18n";
 
 interface Props extends InjectedTranslateProps {
 	url?: string;
@@ -68,7 +68,7 @@ class StreamThumbnail extends React.Component<Props> {
 
 		let viewers = null;
 		if (this.props.viewerCount !== undefined) {
-			const viewerCount = commaSeparate(this.props.viewerCount);
+			const viewerCount = formatNumber(+this.props.viewerCount) as any;
 			viewers = (
 				<span>
 					{t(

--- a/hsreplaynet/static/scripts/src/components/box/WinrateBox.tsx
+++ b/hsreplaynet/static/scripts/src/components/box/WinrateBox.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { InjectedTranslateProps, Trans, translate } from "react-i18next";
 import { AutoSizer } from "react-virtualized";
-import { commaSeparate, toDynamicFixed, winrateData } from "../../helpers";
+import { toDynamicFixed, winrateData } from "../../helpers";
 import { LoadingStatus } from "../../interfaces";
 import WinrateLineChart from "./WinrateLineChart";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	chartData?: any;
@@ -43,7 +44,7 @@ class WinrateBox extends React.Component<Props> {
 					{toDynamicFixed(this.props.winrate, 2)}%
 				</h1>
 			);
-			const gameCount = commaSeparate(this.props.games);
+			const gameCount = formatNumber(this.props.games);
 			content =
 				// prettier-ignore
 				<Trans>

--- a/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/CardDetailPieChart.tsx
@@ -8,6 +8,7 @@ import {
 import { getChartScheme, pieScaleTransform, toTitleCase } from "../../helpers";
 import { ChartScheme, RenderData } from "../../interfaces";
 import { InjectedTranslateProps, translate } from "react-i18next";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	data?: RenderData;
@@ -103,10 +104,10 @@ class CardDetailPieChart extends React.Component<Props> {
 					animate={{ duration: 300 }}
 					labels={d => {
 						if (d.x === "other" && this.props.percentage) {
-							return "<" + d.y.toFixed(0) + "%";
+							return "<" + formatNumber(d.y) + "%";
 						}
 						return this.props.percentage
-							? d.y.toFixed(1) + "%"
+							? formatNumber(d.y, 1) + "%"
 							: d.y;
 					}}
 					height={400}

--- a/hsreplaynet/static/scripts/src/components/charts/ClassDistributionPieChart.tsx
+++ b/hsreplaynet/static/scripts/src/components/charts/ClassDistributionPieChart.tsx
@@ -3,6 +3,7 @@ import { VictoryContainer, VictoryPie } from "victory";
 import { getHeroColor, pieScaleTransform } from "../../helpers";
 import PrettyCardClass from "../text/PrettyCardClass";
 import { InjectedTranslateProps, Trans, translate } from "react-i18next";
+import { formatNumber } from "../../i18n";
 
 export interface Props extends InjectedTranslateProps {
 	data: any[];
@@ -85,7 +86,9 @@ class ClassDistributionPieChart extends React.Component<Props, State> {
 					labels={d =>
 						this.props.loading || !gameCount
 							? null
-							: Math.round(1000 / gameCount * d.y) / 10 + "%"
+							: formatNumber(
+									Math.round(1000 / gameCount * d.y) / 10,
+							  ) + "%"
 					}
 					events={[
 						{

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
@@ -3,6 +3,7 @@ import { InjectedTranslateProps, Trans, translate } from "react-i18next";
 import { winrateData } from "../../helpers";
 import { TableData } from "../../interfaces";
 import PrettyCardClass from "../text/PrettyCardClass";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	opponentWinrateData?: TableData;
@@ -27,7 +28,7 @@ class DeckOverviewTable extends React.Component<Props> {
 			return (
 				<td className="winrate-cell" style={{ color: wrData.color }}>
 					{tendency && wrData.tendencyStr}
-					{winrate.toFixed(2) + "%"}
+					{formatNumber(winrate, 1) + "%"}
 				</td>
 			);
 		};
@@ -83,7 +84,9 @@ class DeckOverviewTable extends React.Component<Props> {
 					</tr>
 					<tr>
 						<td>{t("Turns")}</td>
-						<td>{deck && deck.avg_num_player_turns}</td>
+						<td>
+							{deck && formatNumber(deck.avg_num_player_turns, 1)}
+						</td>
 					</tr>
 					<tr>
 						<td>{t("Turn duration")}</td>

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckOverviewTable.tsx
@@ -76,9 +76,10 @@ class DeckOverviewTable extends React.Component<Props> {
 						<td>
 							{deck &&
 								t("{durationInMinutes} minutes", {
-									durationInMinutes: (
-										deck.avg_game_length_seconds / 60
-									).toFixed(1),
+									durationInMinutes: formatNumber(
+										deck.avg_game_length_seconds / 60,
+										1,
+									),
 								})}
 						</td>
 					</tr>

--- a/hsreplaynet/static/scripts/src/components/deckdetail/DeckStatsWinrates.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/DeckStatsWinrates.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TableData } from "../../interfaces";
 import PrettyCardClass from "../text/PrettyCardClass";
 import { InjectedTranslateProps, Trans, translate } from "react-i18next";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	data?: TableData;
@@ -27,7 +28,7 @@ class DeckStatsWinrates extends React.Component<Props> {
 				<li>
 					<Trans defaults="vs. <0></0>" components={[playerClass]} />
 					<span className="infobox-value">
-						{(+winrate).toFixed(1) + "%"}
+						{formatNumber(+winrate, 1) + "%"}
 					</span>
 				</li>,
 			);

--- a/hsreplaynet/static/scripts/src/components/deckdetail/WinrateBreakdownTable.tsx
+++ b/hsreplaynet/static/scripts/src/components/deckdetail/WinrateBreakdownTable.tsx
@@ -4,6 +4,7 @@ import { winrateData } from "../../helpers";
 import { SortDirection, TableData } from "../../interfaces";
 import SortableTable from "../SortableTable";
 import PrettyCardClass from "../text/PrettyCardClass";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	opponentWinrateData?: TableData;
@@ -38,7 +39,7 @@ class WinrateBreakdownTable extends React.Component<Props, State> {
 			return (
 				<td className="winrate-cell" style={{ color: wrData.color }}>
 					{wrData.tendencyStr}
-					{winrate.toFixed(2) + "%"}
+					{formatNumber(winrate, 2) + "%"}
 				</td>
 			);
 		};

--- a/hsreplaynet/static/scripts/src/components/discover/ClusterDetail.tsx
+++ b/hsreplaynet/static/scripts/src/components/discover/ClusterDetail.tsx
@@ -3,11 +3,11 @@ import React, { Fragment } from "react";
 import { InjectedTranslateProps, translate } from "react-i18next";
 import CardData from "../../CardData";
 import UserData from "../../UserData";
-import { commaSeparate } from "../../helpers";
 import { ArchetypeSignature } from "../../utils/api";
 import CardList from "../CardList";
 import { ClusterData, DeckData } from "./ClassAnalysis";
 import ClusterSignature from "./ClusterSignature";
+import { formatNumber } from "../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	cardData: CardData | null;
@@ -53,7 +53,7 @@ class ClusterDetail extends React.Component<Props> {
 						<tbody>
 							<tr>
 								<th>{t("Total games")}</th>
-								<td>{commaSeparate(totalGames)}</td>
+								<td>{formatNumber(totalGames)}</td>
 							</tr>
 							<tr>
 								<th>{t("Total decks")}</th>

--- a/hsreplaynet/static/scripts/src/components/discover/ClusterSignature.tsx
+++ b/hsreplaynet/static/scripts/src/components/discover/ClusterSignature.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import CardTable from "../tables/CardTable";
 import { SortDirection } from "../../interfaces";
 import CardData from "../../CardData";
-import { toDynamicFixed } from "../../helpers";
 import { ArchetypeSignature } from "../../utils/api";
 
 interface Props {
@@ -38,7 +37,7 @@ export default class ClusterSignature extends React.Component<Props, State> {
 			cards.push({ card: cardData.fromDbf(dbfId), count: 1 });
 			prevalences.push({
 				dbf_id: dbfId,
-				prevalence: toDynamicFixed(prevalence, 3),
+				prevalence,
 			});
 		});
 		return (

--- a/hsreplaynet/static/scripts/src/components/home/ReplayFeed.tsx
+++ b/hsreplaynet/static/scripts/src/components/home/ReplayFeed.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { InjectedTranslateProps, translate } from "react-i18next";
 import DataManager from "../../DataManager";
 import { BnetGameType } from "../../hearthstone";
-import { commaSeparate, image } from "../../helpers";
+import { image } from "../../helpers";
 import { Archetype } from "../../utils/api";
 import RankIcon from "../RankIcon";
 import { withLoading } from "../loading/Loading";
 import ScrollingFeed from "./ScrollingFeed";
+import { formatNumber } from "../../i18n";
 
 interface ReplayData {
 	player1_rank: string;
@@ -85,7 +86,7 @@ class ReplayFeed extends React.Component<Props, State> {
 				const now = this.getMillisecondsOfDay();
 				const factor = now / this.state.startTime;
 				const games = Math.floor(this.getAdjustedGamesToday() * factor);
-				this.counterRef.innerHTML = commaSeparate(games);
+				this.counterRef.innerHTML = formatNumber(games);
 			});
 		}, 10);
 	}
@@ -173,7 +174,7 @@ class ReplayFeed extends React.Component<Props, State> {
 				<div id="replay-feed">
 					<h1>
 						{t("Games Last 7 Days:")}{" "}
-						{commaSeparate(this.props.gamesCountData.games_weekly)}
+						{formatNumber(this.props.gamesCountData.games_weekly)}
 					</h1>
 					<h4>
 						{t("Games Today:")}{" "}
@@ -181,7 +182,7 @@ class ReplayFeed extends React.Component<Props, State> {
 							id="games-count"
 							ref={ref => (this.counterRef = ref)}
 						>
-							{commaSeparate(
+							{formatNumber(
 								Math.floor(this.getAdjustedGamesToday()),
 							)}
 						</span>
@@ -199,7 +200,7 @@ class ReplayFeed extends React.Component<Props, State> {
 					/>
 					<div id="replay-contributors">
 						{t("Contributors:")}{" "}
-						{commaSeparate(
+						{formatNumber(
 							this.props.gamesCountData.contributors_weekly,
 						)}
 					</div>

--- a/hsreplaynet/static/scripts/src/components/metaoverview/matchups/ColumnFooter.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/matchups/ColumnFooter.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import _ from "lodash";
 import Bar, { BarDirection } from "./Bar";
 import { ArchetypeData } from "../../../interfaces";
+import { formatNumber } from "../../../i18n";
 
 interface Props {
 	archetypeData: ArchetypeData;
@@ -87,7 +88,10 @@ export default class ColumnFooter extends React.Component<Props, State> {
 					total={this.props.max ? this.props.max : 100}
 					value={value}
 					direction={BarDirection.VERTICAL}
-					label={`${this.props.archetypeData.popularityTotal}%`}
+					label={`${formatNumber(
+						this.props.archetypeData.popularityTotal,
+						2,
+					)}%`}
 					valueElement={element}
 				/>
 			</div>

--- a/hsreplaynet/static/scripts/src/components/metaoverview/matchups/MatchupCell.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/matchups/MatchupCell.tsx
@@ -2,13 +2,10 @@ import _ from "lodash";
 import React from "react";
 import { InjectedTranslateProps, translate } from "react-i18next";
 import { Colors } from "../../../Colors";
-import {
-	commaSeparate,
-	getColorString,
-	toDynamicFixed,
-} from "../../../helpers";
+import { getColorString, toDynamicFixed } from "../../../helpers";
 import { MatchupData } from "../../../interfaces";
 import Tooltip from "../../Tooltip";
+import { formatNumber } from "../../../i18n";
 
 interface Props extends InjectedTranslateProps {
 	highlightColumn?: boolean;
@@ -110,7 +107,7 @@ class MatchupCell extends React.Component<Props> {
 								<tr>
 									<th>{t("Games:")}</th>
 									<td>
-										{commaSeparate(
+										{formatNumber(
 											matchupData.totalGames || 0,
 										)}
 									</td>
@@ -119,7 +116,7 @@ class MatchupCell extends React.Component<Props> {
 						</div>
 					}
 				>
-					{`${winrate.toFixed(2)}%`}
+					{formatNumber(winrate, 2)}%
 				</Tooltip>
 			);
 		} else {

--- a/hsreplaynet/static/scripts/src/components/metaoverview/matchups/RowFooter.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/matchups/RowFooter.tsx
@@ -3,6 +3,7 @@ import _ from "lodash";
 import { ArchetypeData } from "../../../interfaces";
 import { getColorString } from "../../../helpers";
 import { Colors } from "../../../Colors";
+import { formatNumber } from "../../../i18n";
 
 interface Props {
 	archetypeData?: ArchetypeData;
@@ -39,7 +40,7 @@ export default class RowFooter extends React.Component<Props> {
 			false,
 		);
 
-		const label = isNaN(winrate) ? "-" : winrate + "%";
+		const label = isNaN(winrate) ? "-" : formatNumber(winrate, 2) + "%";
 
 		style.backgroundColor = color;
 

--- a/hsreplaynet/static/scripts/src/components/metaoverview/popularity/ColumnFooter.tsx
+++ b/hsreplaynet/static/scripts/src/components/metaoverview/popularity/ColumnFooter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { commaSeparate } from "../../../helpers";
+import { formatNumber } from "../../../i18n";
 
 interface Props {
 	games: number;
@@ -26,7 +26,7 @@ export default class ColumnFooter extends React.Component<Props> {
 				className="matchup-column-footer matchup-column-footer-games popularity-column-footer"
 				style={{ color, backgroundColor, ...this.props.style }}
 			>
-				{commaSeparate(this.props.games)}
+				{formatNumber(this.props.games)}
 			</div>
 		);
 	}

--- a/hsreplaynet/static/scripts/src/components/tables/Table.tsx
+++ b/hsreplaynet/static/scripts/src/components/tables/Table.tsx
@@ -4,7 +4,12 @@ import { AutoSizer, Grid, ScrollSync } from "react-virtualized";
 import { SortableProps, SortDirection } from "../../interfaces";
 import scrollbarSize from "dom-helpers/util/scrollbarSize";
 import SortHeader from "../SortHeader";
-import { toDynamicFixed, toPrettyNumber, winrateData } from "../../helpers";
+import {
+	sliceZeros,
+	toDynamicFixed,
+	toPrettyNumber,
+	winrateData,
+} from "../../helpers";
 import Tooltip from "../Tooltip";
 
 export interface TableColumn {
@@ -346,6 +351,8 @@ export default class Table extends React.Component<Props, State> {
 				content = toDynamicFixed(+content) + "%";
 			} else if (column.prettify) {
 				content = toPrettyNumber(+content);
+			} else {
+				content = sliceZeros(toDynamicFixed(+content));
 			}
 		}
 

--- a/hsreplaynet/static/scripts/src/helpers.ts
+++ b/hsreplaynet/static/scripts/src/helpers.ts
@@ -747,7 +747,7 @@ export function winrateData(
 	const tendencyStr =
 		winrateDelta === 0 ? "    " : winrateDelta > 0 ? "▲" : "▼";
 	const color = getColorString(Colors.REDGREEN3, 75, colorWinrate / 100);
-	return { delta: winrateDelta.toFixed(1), color, tendencyStr };
+	return { delta: formatNumber(winrateDelta, 1), color, tendencyStr };
 }
 
 export function cleanText(text: string): string {

--- a/hsreplaynet/static/scripts/src/i18n.ts
+++ b/hsreplaynet/static/scripts/src/i18n.ts
@@ -14,16 +14,68 @@ import pt from "i18next-icu/locale-data/pt";
 import ru from "i18next-icu/locale-data/ru";
 import th from "i18next-icu/locale-data/th";
 import zh from "i18next-icu/locale-data/zh";
+import numbro from "numbro";
+import * as numbroDe from "numbro/languages/de-DE";
+import * as numbroEn from "numbro/languages/en-GB";
+import * as numbroEs from "numbro/languages/es-ES";
+import * as numbroFr from "numbro/languages/fr-FR";
+import * as numbroIt from "numbro/languages/it-IT";
+import * as numbroJa from "numbro/languages/ja-JP";
+import * as numbroKo from "numbro/languages/ko-KR";
+import * as numbroPl from "numbro/languages/pl-PL";
+import * as numbroPt from "numbro/languages/pt-PT";
+import * as numbroRu from "numbro/languages/ru-RU";
+import * as numbroTh from "numbro/languages/th-TH";
+import * as numbroZh from "numbro/languages/zh-CN";
 import UserData from "./UserData";
 
 export const I18N_NAMESPACE_FRONTEND = "frontend";
 export const I18N_NAMESPACE_HEARTHSTONE = "hearthstone";
+
+const supportedLocales = {
+	de: { numbro: "de-DE" },
+	en: { numbro: "en-GB" },
+	es: { numbro: "es-ES" },
+	fr: { numbro: "fr-FR" },
+	it: { numbro: "it-IT" },
+	ja: { numbro: "ja-JP" },
+	ko: { numbro: "ko-KR" },
+	pl: { numbro: "pl-PL" },
+	pt: { numbro: "pt-PT" },
+	ru: { numbro: "ru-RU" },
+	th: { numbro: "th-TH" },
+	zh: { numbro: "zh-CN" },
+};
 
 // just used while we feature flag frontend translations
 UserData.create();
 
 // create icu as instance so we can clear memoization cache (see below)
 const icu = new ICU();
+
+[
+	numbroDe,
+	numbroEn,
+	numbroEs,
+	numbroFr,
+	numbroIt,
+	numbroJa,
+	numbroKo,
+	numbroPl,
+	numbroPt,
+	numbroRu,
+	numbroTh,
+	numbroZh,
+].forEach(locale => {
+	numbro.registerLanguage(locale);
+});
+
+export function formatNumber(n: number, mantissa: number = 0): string {
+	if (n === undefined || n === null) {
+		return null;
+	}
+	return numbro(n).format({ thousandSeparated: true, mantissa });
+}
 
 i18n
 	.use(CustomCallbackBackend)
@@ -55,6 +107,7 @@ i18n
 
 		// CustomCallbackBackend
 		customLoad: async (language, namespace, callback) => {
+			numbro.setLanguage(supportedLocales[language].numbro);
 			const translations = {};
 			if (namespace === "translation") {
 				// default fallback namespace, do not load

--- a/hsreplaynet/static/scripts/src/i18n.ts
+++ b/hsreplaynet/static/scripts/src/i18n.ts
@@ -15,36 +15,36 @@ import ru from "i18next-icu/locale-data/ru";
 import th from "i18next-icu/locale-data/th";
 import zh from "i18next-icu/locale-data/zh";
 import numbro from "numbro";
-import * as numbroDe from "numbro/languages/de-DE";
-import * as numbroEn from "numbro/languages/en-GB";
-import * as numbroEs from "numbro/languages/es-ES";
-import * as numbroFr from "numbro/languages/fr-FR";
-import * as numbroIt from "numbro/languages/it-IT";
-import * as numbroJa from "numbro/languages/ja-JP";
-import * as numbroKo from "numbro/languages/ko-KR";
-import * as numbroPl from "numbro/languages/pl-PL";
-import * as numbroPt from "numbro/languages/pt-PT";
-import * as numbroRu from "numbro/languages/ru-RU";
-import * as numbroTh from "numbro/languages/th-TH";
-import * as numbroZh from "numbro/languages/zh-CN";
+import numbroDe from "numbro/languages/de-DE";
+import numbroEn from "numbro/languages/en-GB";
+import numbroEs from "numbro/languages/es-ES";
+import numbroFr from "numbro/languages/fr-FR";
+import numbroIt from "numbro/languages/it-IT";
+import numbroJa from "numbro/languages/ja-JP";
+import numbroKo from "numbro/languages/ko-KR";
+import numbroPl from "numbro/languages/pl-PL";
+import numbroPt from "numbro/languages/pt-PT";
+import numbroRu from "numbro/languages/ru-RU";
+import numbroTh from "numbro/languages/th-TH";
+import numbroZh from "numbro/languages/zh-CN";
 import UserData from "./UserData";
 
 export const I18N_NAMESPACE_FRONTEND = "frontend";
 export const I18N_NAMESPACE_HEARTHSTONE = "hearthstone";
 
-const supportedLocales = {
-	de: { numbro: "de-DE" },
-	en: { numbro: "en-GB" },
-	es: { numbro: "es-ES" },
-	fr: { numbro: "fr-FR" },
-	it: { numbro: "it-IT" },
-	ja: { numbro: "ja-JP" },
-	ko: { numbro: "ko-KR" },
-	pl: { numbro: "pl-PL" },
-	pt: { numbro: "pt-PT" },
-	ru: { numbro: "ru-RU" },
-	th: { numbro: "th-TH" },
-	zh: { numbro: "zh-CN" },
+const numbroLocales = {
+	de: "de-DE",
+	en: "en-GB",
+	es: "es-ES",
+	fr: "fr-FR",
+	it: "it-IT",
+	ja: "ja-JP",
+	ko: "ko-KR",
+	pl: "pl-PL",
+	pt: "pt-PT",
+	ru: "ru-RU",
+	th: "th-TH",
+	zh: "zh-CN",
 };
 
 // just used while we feature flag frontend translations
@@ -107,7 +107,7 @@ i18n
 
 		// CustomCallbackBackend
 		customLoad: async (language, namespace, callback) => {
-			numbro.setLanguage(supportedLocales[language].numbro);
+			numbro.setLanguage(numbroLocales[language]);
 			const translations = {};
 			if (namespace === "translation") {
 				// default fallback namespace, do not load

--- a/hsreplaynet/static/scripts/src/pages/MetaOverview.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MetaOverview.tsx
@@ -20,8 +20,8 @@ import PremiumWrapper from "../components/premium/PremiumWrapper";
 import RankPicker from "../components/rankpicker/RankPicker";
 import PrettyTimeRange from "../components/text/PrettyTimeRange";
 import { TimeRange } from "../filters";
-import { commaSeparate } from "../helpers";
 import { SortDirection } from "../interfaces";
+import { formatNumber } from "../i18n";
 
 interface Props extends InjectedTranslateProps {
 	cardData: CardData;
@@ -257,11 +257,11 @@ class MetaOverview extends React.Component<Props, State> {
 								}}
 								extract={{
 									data: data => ({
-										contributors: commaSeparate(
+										contributors: formatNumber(
 											data.series.metadata.totals
 												.contributors,
 										),
-										games: commaSeparate(
+										games: formatNumber(
 											data.series.metadata.totals
 												.total_games,
 										),

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"i18next-icu": "^0.4.0",
 		"lodash": "^4.17.4",
 		"node-sass": "^4.7.2",
+		"numbro": "^2.0.6",
 		"prop-types": "^15.6.0",
 		"raven-js": "^3.20.1",
 		"react": "^16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,6 +1083,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+bignumber.js@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -3960,6 +3964,12 @@ num2fraction@^1.2.2:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+numbro@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/numbro/-/numbro-2.0.6.tgz#d46acaa11aa879d522e93651de3926646d6db100"
+  dependencies:
+    bignumber.js "^4.0.4"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"


### PR DESCRIPTION
This PR localizes numbers on the site using numbro.js.

## Localization work
This localized all:
- Decimals
- Percentages 
- Comma separated numbers.

This does **not** localize:
- Integers without comma separation (e.g. dust values)
- Any numbers that are part of time spans (happens as part of #783)

## Change summary and other things that happened
- Almost all percentages and decimals now consistently use one digit after the decimal point. The two exceptions to this are:
  - Anything using `toDynamicFixed`, where it is dynamically determined based on the magnitude (e.g. to correctly display values like `0.00043`)
  - The cells on the matchup and popularity tabs on `/meta/`. There is no technical reason here but it looked somewhat weird. I'd be fine doing this here too if we want to be completely consistent. 
- `helpers.commaSeparate` has been removed and completely replaced with the localization call.
- `helpers.sliceZeros` got a couple bug fixes, now correctly slicing `000` and `0` to `0` and automatically removing the trailing comma (`1.0` results in `1` instead of `1.`).

## Remaining work
- We could consider adding a `<FormattedNumber>` component and use it where applicable, but the number of instances where this makes it unnecessarily complicated seems too high, so that opted against that for now.
- I'm uncertain whether anything in `i18n.ts` is the correct way to do it. Hopefully @beheh can help out here.
  - Importing as `import de from "numbro/languages/de-DE"` (as suggested in #307) does not work as "de" and all other languages are already defined as imports.
  - Importing as `import * as numbroLangs from "numbro/languages` does not seem to work.
  - One thing to note is also that the full language strings (e.g. `en-GB` instead of `en-US`) do not line up with the ones used in Hearthstone. `en-US` does not exist in numbro.
  - I don't know whether having the `setLanguage` as part of the `customLoad` call is the correct way to do it, but it seems to work. 
