### PR TITLE
Cleanup Redshift loading

### DIFF
--- a/hsreplaynet/games/processing.py
+++ b/hsreplaynet/games/processing.py
@@ -1129,60 +1129,58 @@ def do_process_upload_event(upload_event):
 	# Defer flushing the exporter until after the UploadEvent is set to SUCCESS
 	# So that the player can start watching their replay sooner
 	def do_flush_exporter():
+		# Check whether game is eligible for Redshift
 		if not should_load_into_redshift(upload_event, global_game):
 			return
 
-		can_attempt_redshift_load = False
+		# Attempt to claim the advisory_lock
+		can_attempt_redshift_load = global_game.acquire_redshift_lock()
+		if not can_attempt_redshift_load:
+			log.debug("Failed to acquire Redshift lock, will not flush")
+			return
 
-		if global_game.loaded_into_redshift is None:
-			log.debug("Global game has not been loaded into redshift")
-			# Attempt to claim the advisory_lock, if successful:
-			can_attempt_redshift_load = global_game.acquire_redshift_lock()
-			if can_attempt_redshift_load:
-				# We update GlobalGame to see whether another process might have updated
-				# loaded_into_redshift in the meantime
-				global_game.refresh_from_db()
-				if global_game.loaded_into_redshift is not None:
-					can_attempt_redshift_load = False
-		else:
-			log.debug("Global game has already been loaded into Redshift")
+		# We update GlobalGame to see whether another process might have updated
+		# loaded_into_redshift in the meantime
+		global_game.refresh_from_db()
+		if global_game.loaded_into_redshift is not None:
+			log.debug("Global game has already been loaded into Redshift, will not flush")
+			global_game.release_redshift_lock()
+			return
 
 		# Only if we were able to claim the advisory lock do we proceed here.
-		if can_attempt_redshift_load:
-			log.debug("Redshift lock acquired. Will attempt to flush to redshift")
+		log.debug("Redshift lock acquired, will attempt to flush")
 
-			with influx_timer("generate_redshift_game_info_duration"):
-				game_info = get_game_info(global_game, replay)
-			exporter.set_game_info(game_info)
+		with influx_timer("generate_redshift_game_info_duration"):
+			game_info = get_game_info(global_game, replay)
+		exporter.set_game_info(game_info)
 
-			try:
-				with influx_timer("flush_exporter_to_firehose_duration"):
-					flush_failures_report = flush_exporter_to_firehose(
-						exporter,
-						records_to_flush=get_records_to_flush()
-					)
-					for target_table, errors in flush_failures_report.items():
-						for error in errors:
-							influx_metric(
-								"firehose_flush_failure",
-								{
-									"stream_name": error["stream_name"],
-									"error_code": error["error_code"],
-									"error_message": error["error_message"],
-									"count": 1
-								},
-								target_table=target_table
-							)
-			except Exception:
-				raise
-			else:
-				global_game.loaded_into_redshift = timezone.now()
-				global_game.save()
-				# Okay to release the advisory lock once loaded_into_redshift is set
-				# It will also be released automatically when the lambda exits.
-				global_game.release_redshift_lock()
+		try:
+			with influx_timer("flush_exporter_to_firehose_duration"):
+				flush_failures_report = flush_exporter_to_firehose(
+					exporter,
+					records_to_flush=get_records_to_flush()
+				)
+				for target_table, errors in flush_failures_report.items():
+					for error in errors:
+						influx_metric(
+							"firehose_flush_failure",
+							{
+								"stream_name": error["stream_name"],
+								"error_code": error["error_code"],
+								"error_message": error["error_message"],
+								"count": 1
+							},
+							target_table=target_table
+						)
+		except Exception:
+			raise
 		else:
-			log.debug("Did not acquire redshift lock. Will not flush to redshift")
+			global_game.loaded_into_redshift = timezone.now()
+			global_game.save()
+		finally:
+			# Release the lock in any case, but only after loaded_into_redshift was set
+			# It would also be released automatically once the lambda exits
+			global_game.release_redshift_lock()
 
 	return replay, do_flush_exporter
 


### PR DESCRIPTION
This PR simplifies the `do_flush_exporter` code path and uses early returns instead of nested else statements to make it more readable. I've also rearranged the method so that `should_load_into_redshift` is called earlier, which means we don't even attempt to claim the lock if Redshift loading is disabled (such as in a test environment) or the game is not eligible for statistics.

Additionally, I've also cleared up some ambiguity about relying on the Lambda exit to release the lock, and instead clear it explicitly.