### PR TITLE
New Replay API

### DIFF
--- a/hsreplaynet/api/fields.py
+++ b/hsreplaynet/api/fields.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import serializers
+
+
+class IntEnumField(serializers.Field):
+	default_error_messages = {
+		"invalid_member": _("{input} is not a valid member of {enum}.")
+	}
+
+	def __init__(self, enum, *args, **kwargs):
+		assert enum
+		self.enum = enum
+		super(IntEnumField, self).__init__(*args, **kwargs)
+
+	def to_representation(self, value):
+		return int(value)
+
+	def to_internal_value(self, value):
+		try:
+			enum = self.enum(int(value))
+		except ValueError:
+			self.fail("invalid_member", input=value, enum=self.enum.__name__)
+		return enum
+
+
+class TimestampField(serializers.DateTimeField):
+	precision = 1
+
+	def __init__(self, precision=None, *args, **kwargs):
+		if precision is not None:
+			self.precision = precision
+		super(TimestampField, self).__init__(*args, **kwargs)
+
+	def to_representation(self, value):
+		dt = datetime.utcfromtimestamp(value / self.precision)
+		return super(TimestampField, self).to_representation(dt)
+
+	def to_internal_value(self, value):
+		dt = super(TimestampField, self).to_internal_value(value)
+		return dt.timestamp() * self.precision

--- a/hsreplaynet/api/serializers/replays.py
+++ b/hsreplaynet/api/serializers/replays.py
@@ -1,0 +1,73 @@
+from hearthstone import enums
+from rest_framework import fields, serializers
+
+from hearthsim.identity.accounts.models import Visibility
+
+from ..fields import IntEnumField, TimestampField
+
+
+class GameReplaySerializer(serializers.Serializer):
+	user_id = fields.IntegerField()
+	match_start = TimestampField(precision=1000)
+	match_end = TimestampField(precision=1000)
+
+	shortid = fields.CharField(source="short_id")
+	digest = fields.CharField(allow_null=True)
+
+	game_type = IntEnumField(enums.BnetGameType)
+	format_type = IntEnumField(enums.FormatType)
+
+	ladder_season = fields.IntegerField(allow_null=True)
+	brawl_season = fields.IntegerField(allow_null=True)
+	scenario_id = fields.IntegerField(allow_null=True)
+	num_turns = fields.IntegerField()
+
+	friendly_player_account_hi = fields.SerializerMethodField()
+	friendly_player_account_lo = fields.SerializerMethodField()
+
+	friendly_player_battletag = fields.CharField()
+	friendly_player_is_first = fields.BooleanField()
+	friendly_player_rank = fields.IntegerField(allow_null=True)
+	friendly_player_legend_rank = fields.IntegerField(allow_null=True)
+	friendly_player_rank_stars = fields.IntegerField(allow_null=True)
+	friendly_player_wins = fields.IntegerField(allow_null=True)
+	friendly_player_losses = fields.IntegerField(allow_null=True)
+	friendly_player_class = IntEnumField(enums.CardClass)
+	friendly_player_hero = fields.IntegerField()
+	friendly_player_deck = fields.CharField()
+	friendly_player_blizzard_deck_id = fields.IntegerField(allow_null=True)
+	friendly_player_cardback_id = fields.IntegerField(allow_null=True)
+	friendly_player_final_state = IntEnumField(enums.PlayState)
+
+	opponent_account_hi = fields.SerializerMethodField()
+	opponent_account_lo = fields.SerializerMethodField()
+
+	opponent_battletag = fields.CharField()
+	opponent_is_ai = fields.BooleanField()
+	opponent_rank = fields.IntegerField(allow_null=True)
+	opponent_legend_rank = fields.IntegerField(allow_null=True)
+	opponent_class = IntEnumField(enums.CardClass)
+	opponent_hero = fields.IntegerField()
+	opponent_revealed_deck = fields.CharField()
+	opponent_predicted_deck = fields.CharField(allow_null=True)
+	opponent_cardback_id = fields.IntegerField(allow_null=True)
+	opponent_final_state = IntEnumField(enums.PlayState)
+
+	replay_xml = fields.CharField()
+	hslog_version = fields.CharField()
+	disconnected = fields.BooleanField(default=False)
+	reconnecting = fields.BooleanField(default=False)
+	visibility = IntEnumField(Visibility)
+	views = fields.IntegerField()
+
+	def get_friendly_player_account_hi(self, instance):
+		return instance.friendly_player_account_hilo.split("_")[0]
+
+	def get_friendly_player_account_lo(self, instance):
+		return instance.friendly_player_account_hilo.split("_")[1]
+
+	def get_opponent_account_hi(self, instance):
+		return instance.opponent_account_hilo.split("_")[0]
+
+	def get_opponent_account_lo(self, instance):
+		return instance.opponent_account_hilo.split("_")[1]

--- a/hsreplaynet/api/urls.py
+++ b/hsreplaynet/api/urls.py
@@ -43,6 +43,8 @@ urlpatterns = [
 	url(r"^v1/decks/(?P<shortid>\w+)/feedback/$", DeckFeedbackView.as_view()),
 	url(r"^v1/games/$", views.games.GameReplayList.as_view()),
 	url(r"^v1/games/(?P<shortid>.+)/$", views.games.GameReplayDetail.as_view()),
+	url(r"^v1/replays/$", views.replays.GameReplayListView.as_view()),
+	url(r"^v1/replays/(?P<shortid>.+)/$", views.replays.GameReplayView.as_view()),
 	url(r"^v1/analytics/global/$", views.analytics.GlobalAnalyticsQueryView.as_view()),
 	url(r"^v1/analytics/personal/$", views.analytics.PersonalAnalyticsQueryView.as_view()),
 	url(r"^v1/features/(?P<name>[\w-]+)/$", SetFeatureView.as_view()),

--- a/hsreplaynet/api/views/__init__.py
+++ b/hsreplaynet/api/views/__init__.py
@@ -1,4 +1,4 @@
-from . import ads, accounts, analytics, collections, games, packs, webhooks, vods
+from . import ads, accounts, analytics, collections, games, packs, replays, webhooks, vods
 
 __all__ = [
 	"ads",
@@ -7,6 +7,7 @@ __all__ = [
 	"collections",
 	"games",
 	"packs",
+	"replays",
 	"webhooks",
 	"vods",
 ]

--- a/hsreplaynet/api/views/replays.py
+++ b/hsreplaynet/api/views/replays.py
@@ -1,0 +1,132 @@
+import json
+from types import GeneratorType
+
+from django.contrib.auth import get_user_model
+from django.http import StreamingHttpResponse
+from hearthstone import enums
+from rest_framework import fields, renderers, serializers, views
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.utils import encoders
+
+from hsreplaynet.api.permissions import UserHasFeature
+from hsreplaynet.games.models.dynamodb import GameReplay
+
+from ..fields import IntEnumField, TimestampField
+from ..serializers.replays import GameReplaySerializer
+
+
+class GameReplayView(views.APIView):
+	serializer_class = GameReplaySerializer
+
+	def get(self, request, shortid, **kwargs):
+		results = GameReplay.short_id_index.query(shortid)
+		try:
+			index = results.next()
+		except StopIteration:
+			raise NotFound()
+
+		replay = GameReplay.get(index.user_id, index.match_start)
+		serializer = self.serializer_class(instance=replay)
+		return Response(serializer.data)
+
+
+class StreamingJSONRenderer(renderers.BaseRenderer):
+	media_type = "application/json"
+	format = "json"
+	encoder_class = encoders.JSONEncoder
+
+	def render(self, data, accepted_media_type=None, renderer_context=None):
+		if data is None:
+			yield "[]"
+			return
+
+		if not isinstance(data, GeneratorType) and not isinstance(data, list):
+			yield json.dumps(data, cls=self.encoder_class)
+			return
+
+		yield "["
+		try:
+			is_first = True
+			for item in data:
+				if not is_first:
+					yield ","
+				else:
+					is_first = False
+				yield json.dumps(item, cls=self.encoder_class)
+		except (Exception) as e:
+			yield "]"
+			raise e
+		else:
+			yield "]"
+
+
+class GameReplayRequestSerializer(serializers.Serializer):
+	user_id = fields.IntegerField()
+	start_date = TimestampField(precision=1000, required=False, default=None)
+	end_date = TimestampField(precision=1000, required=False, default=None)
+	game_type = IntEnumField(enums.BnetGameType, required=False, default=None)
+
+	def validate(self, data):
+		START_DATE_FIELD = "start_date"
+		END_DATE_FIELD = "end_date"
+		if data[START_DATE_FIELD] is not None and data[END_DATE_FIELD] is not None:
+			if data[START_DATE_FIELD] > data[END_DATE_FIELD]:
+				msg = "%s must be before %s." % (START_DATE_FIELD, END_DATE_FIELD)
+				raise serializers.ValidationError(msg)
+		return data
+
+
+def _stream_replays(
+	user_id, start_date=None, end_date=None, game_type=None,
+	serializer_class=GameReplaySerializer
+):
+	range_key_condition = None
+	if start_date is not None and end_date is not None:
+		range_key_condition = GameReplay.match_start.between(start_date, end_date)
+	else:
+		if start_date is not None:
+			range_key_condition = GameReplay.match_start > start_date
+		if end_date is not None:
+			range_key_condition = GameReplay.match_start < end_date
+
+	filter_condition = None
+	if game_type is not None:
+		filter_condition = GameReplay.game_type == game_type
+
+	for replay in GameReplay.query(
+		user_id, range_key_condition=range_key_condition, filter_condition=filter_condition
+	):
+		serializer = serializer_class(instance=replay)
+		yield serializer.data
+
+
+class GameReplayListView(views.APIView):
+	authentication_classes = (SessionAuthentication, )
+	permission_classes = (IsAuthenticated, UserHasFeature("dynamodb-replays-api"))
+	renderer_classes = (StreamingJSONRenderer,)
+	serializer_class = GameReplayRequestSerializer
+
+	def get(self, request, **kwargs):
+		input = self.serializer_class(data=request.query_params)
+		input.is_valid(raise_exception=True)
+
+		User = get_user_model()
+		try:
+			user = User.objects.get(id=input.validated_data["user_id"])
+		except User.DoesNotExist:
+			raise NotFound()
+
+		replays = _stream_replays(
+			user_id=user.id,
+			start_date=input.validated_data["start_date"],
+			end_date=input.validated_data["end_date"],
+			game_type=input.validated_data["game_type"],
+		)
+
+		return StreamingHttpResponse(
+			request.accepted_renderer.render(replays),
+			content_type=request.accepted_renderer.media_type
+		)

--- a/tests/api/replays/test_views.py
+++ b/tests/api/replays/test_views.py
@@ -1,0 +1,158 @@
+import json
+import os
+
+import pytest
+from hearthstone import enums
+from hslog.export import EntityTreeExporter
+from hsreplay.document import HSReplayDocument
+from rest_framework import status
+from tests.conftest import LOG_DATA_DIR
+from tests.test_raw_upload_processing import (  # noqa: F401
+	game_replay_dynamodb_table, multi_db
+)
+
+from hearthsim.identity.accounts.models import Visibility
+from hsreplaynet.games.processing import create_dynamodb_game_replay
+from hsreplaynet.uploads.models import UploadEvent
+
+
+@pytest.fixture
+def public_replay_api(mocker):
+	mocker.patch.multiple(
+		"hsreplaynet.api.views.replays.GameReplayListView",
+		authentication_classes=(),
+		permission_classes=(),
+	)
+
+
+def _parse_streaming_json(iterator):
+	return json.loads(b"".join(iterator))
+
+
+@pytest.mark.usefixtures("public_replay_api")
+def test_replays_api_missing_user_id(client):
+	response = client.get("/api/v1/replays/")
+	assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("game_replay_dynamodb_table", "public_replay_api")
+def test_replays_api_wrong_user_id(client):
+	response = client.get("/api/v1/replays/?user_id=1")
+	assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("game_replay_dynamodb_table", "public_replay_api")
+def test_replays_api_empty(client, user):
+	response = client.get("/api/v1/replays/?user_id=%d" % user.id)
+	assert response.status_code == status.HTTP_200_OK
+	assert _parse_streaming_json(response.streaming_content) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("multi_db", "game_replay_dynamodb_table", "public_replay_api")
+def test_replays_api(auth_token, client):
+	upload_event = UploadEvent(
+		id="1",
+		shortid="ccSgiGQaenVzXzwGYbaUTPGrv",
+		token_uuid=auth_token.key,
+	)
+
+	path = os.path.join(
+		LOG_DATA_DIR,
+		"hsreplaynet-tests",
+		"replays",
+		"whizbang_friendly.annotated.xml"
+	)
+	with open(path, "r") as f:
+		replay = HSReplayDocument.from_xml_file(f)
+	packet_tree = replay.to_packet_tree()[0]
+
+	meta = {
+		"game_type": enums.BnetGameType.BGT_RANKED_STANDARD,
+		"ladder_season": 42,
+		"format": enums.FormatType.FT_STANDARD,
+		"friendly_player": 1,
+		"reconnecting": False,
+		"scenario_id": 2,
+		"start_time": packet_tree.start_time,
+		"end_time": packet_tree.end_time,
+		"player1": {
+			"rank": 20,
+			"stars": 30,
+			"deck": [
+				"BOT_447",
+				"BOT_447",
+				"EX1_319",
+				"EX1_319",
+				"LOOT_014",
+				"LOOT_014",
+				"BOT_263",
+				"BOT_263",
+				"BOT_568",
+				"CS2_065",
+				"CS2_065",
+				"EX1_596",
+				"EX1_596",
+				"BOT_443",
+				"BOT_443",
+				"LOOT_013",
+				"LOOT_013",
+				"BOT_224",
+				"BOT_224",
+				"BOT_226",
+				"BOT_226",
+				"ICC_466",
+				"ICC_466",
+				"ICC_075",
+				"ICC_075",
+				"EX1_310",
+				"EX1_310",
+				"BOT_521",
+				"BOT_521",
+				"ICC_831",
+			],
+			"deck_id": 1337,
+			"cardback": 136,
+		},
+		"player2": {
+			"rank": 19,
+			"cardback": 138,
+		},
+	}
+
+	entity_tree = EntityTreeExporter(packet_tree).export().game
+	replay_xml = "foo.xml"
+
+	replay = create_dynamodb_game_replay(upload_event, meta, entity_tree, replay_xml)
+	replay.save()
+
+	user_id = auth_token.user.id
+
+	response = client.get("/api/v1/replays/?user_id=%d" % (user_id))
+	assert response.status_code == status.HTTP_200_OK
+	payload = _parse_streaming_json(response.streaming_content)[0]
+
+	assert payload["user_id"] == user_id
+	assert payload["match_start"] == "2018-08-08T21:20:02.610000Z"
+	assert payload["match_end"] == "2018-08-08T21:31:10.236000Z"
+	assert payload["shortid"] == "ccSgiGQaenVzXzwGYbaUTPGrv"
+	assert payload["game_type"] == enums.BnetGameType.BGT_RANKED_STANDARD
+	assert payload["format_type"] == enums.FormatType.FT_STANDARD
+
+	assert payload["friendly_player_account_hi"] == "144115193835963207"
+	assert payload["friendly_player_account_lo"] == "127487329"
+	assert payload["friendly_player_battletag"] == "Masture#1176"
+	assert payload["friendly_player_rank"] == 20
+
+	assert payload["opponent_account_hi"] == "144115193835963207"
+	assert payload["opponent_account_lo"] == "50318740"
+	assert payload["opponent_battletag"] == "GinyuGamer#1677"
+	assert payload["opponent_rank"] == 19
+
+	assert payload["replay_xml"] == "foo.xml"
+	assert payload["disconnected"] is False
+	assert payload["reconnecting"] is False
+	assert payload["visibility"] == Visibility.Public
+	assert payload["views"] == 0


### PR DESCRIPTION
This PR adds a new replay API at `/api/v1/replays` that is powered by DynamoDB. Currently it exposes the item nearly 1:1 as the schema we use for writing data to DynamoDB.