### PR TITLE
Implement an inverse lookup table for deck prediction

### DIFF
--- a/hsreplaynet/decks/models.py
+++ b/hsreplaynet/decks/models.py
@@ -4,6 +4,7 @@ import json
 import os
 import string
 import time
+from typing import Set
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField, JSONField
@@ -977,6 +978,13 @@ class ClusterManager(models.Manager):
 						result[external_id]["signature_weights"][int(dbf_id)] = weight
 
 			return result
+
+	def get_required_cards_for_player_class(self, game_format, player_class) -> Set[int]:
+		weights = self.get_signature_weights(game_format, player_class)
+		required_cards = set()
+		for cluster in weights.values():
+			required_cards.add(*cluster["required_cards"])
+		return required_cards
 
 	def get_live_cluster_for_archetype(self, game_format, archetype):
 		return ClusterSnapshot.objects.filter(

--- a/hsreplaynet/settings.py
+++ b/hsreplaynet/settings.py
@@ -492,6 +492,12 @@ DECK_PREDICTION_MINIMUM_CARDS = 3
 # Set false to increase redis brute force search efficiency
 INCLUDE_CURRENT_BUCKET_IN_LOOKUP = False
 
+ILT_DECK_PREDICTION_MINIMUM_CARDS = 3
+# The sliding window duration of card to deck mappings to maintain
+ILT_LOOKBACK_MINS = 60 * 12
+# The sliding window size of deck popularities to maintain
+ILT_DECK_POPULARITY_LOOKBACK_MINS = 60 * 12
+
 # Used in some pages such as /downloads
 FONTAWESOME_CSS_URL = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
 FONTAWESOME_CSS_INTEGRITY = "sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0="

--- a/hsreplaynet/utils/prediction.py
+++ b/hsreplaynet/utils/prediction.py
@@ -1,11 +1,16 @@
 import random
+import time
 from copy import copy
 from datetime import datetime, timedelta
 from random import randrange
+from typing import Dict, Iterable, List, Optional, Set
+from uuid import uuid4
 
 from django.conf import settings
 from hearthstone.enums import CardClass, FormatType
+from redis import StrictRedis
 
+from hsreplaynet.decks.models import ClusterSnapshot
 from hsreplaynet.utils.redis import (
 	SECONDS_PER_DAY, RedisIntegerMapStorage, RedisPopularityDistribution, RedisTree
 )
@@ -239,3 +244,188 @@ class DeckPredictionTree:
 
 				for child in v.children():
 					stack.insert(0, child)
+
+
+class BaseInverseLookupTable:
+	"""
+	This class specificies the API for an Inverse Lookup Table (ILT) to be used for
+	deck prediction.
+	"""
+
+	def observe(
+		self, dbf_map: Dict[int, int], deck_id: int, uuid: Optional[str] = None
+	) -> None:
+		"""
+		This method takes a list of cards as a dict of {card_id: count} items and stores an
+		entry pointing to the deck_id for each of the cards. You may optionally pass a UUID
+		(such as a replay shortid) in order to deduplicate observations.
+		"""
+		raise NotImplementedError
+
+	def predict(self, dbf_map: Dict[int, int]) -> Optional[int]:
+		"""
+		This method takes a list of cards as a dict of {card_id: count} items and attempts
+		to find the most likely deck_id. If none is found, this method will return None.
+		"""
+		raise NotImplementedError
+
+
+class RedisInverseLookupTable(BaseInverseLookupTable):
+	def __init__(
+		self,
+		redis: StrictRedis,
+		game_format: FormatType,
+		player_class: CardClass,
+		required_cards: Optional[Set[int]] = None,
+		min_cards_for_prediction: int = settings.ILT_DECK_PREDICTION_MINIMUM_CARDS,
+		ilt_lookback_mins: int = settings.ILT_LOOKBACK_MINS,
+		deck_popularity_lookback_mins: int = settings.ILT_DECK_POPULARITY_LOOKBACK_MINS,
+		full_deck_size: int = 30,
+	) -> None:
+		self.redis = redis
+		self.game_format = game_format
+		self.player_class = player_class
+		self.required_cards = required_cards or set()
+		self.ilt_lookback_mins = ilt_lookback_mins
+		self.deck_popularity_lookback_mins = deck_popularity_lookback_mins
+		self.min_cards_for_prediction = min_cards_for_prediction
+		self.full_deck_size = full_deck_size
+
+	@property
+	def namespace(self):
+		return f"DECK_PREDICTION_ILT:{self.game_format.name}_{self.player_class.name}"
+
+	def observe(
+		self, dbf_map: Dict[int, int], deck_id: int, uuid: Optional[str] = None
+	) -> None:
+		if not self._is_full_deck(dbf_map):
+			raise ValueError("The deck is not a full deck")
+
+		# grab the current time
+		now = int(time.time() * 1000)
+
+		# pipeline all the following commands
+		pipeline = self.redis.pipeline()
+
+		# observe the cards in ILTs
+		for key in self._get_card_keys(dbf_map):
+			pipeline.zadd(key, now, deck_id)
+			pipeline.expire(key, self.ilt_lookback_mins * 60)
+
+		# observe the deck for popularity
+		deck_key = self._get_deck_key(deck_id)
+		uuid = uuid or str(uuid4())
+		pipeline.zadd(deck_key, now, uuid)
+		pipeline.expire(deck_key, self.deck_popularity_lookback_mins * 60)
+
+		# send the pipeline over the wire
+		pipeline.execute()
+
+	def _is_full_deck(self, dbf_map: Dict[int, int]) -> bool:
+		return sum(count for card_id, count in dbf_map.items()) == self.full_deck_size
+
+	def _get_card_keys(self, dbf_map: Dict[int, int]) -> Set[str]:
+		keys = set()
+		for card_id, count in dbf_map.items():
+			# Also return all permutations with fewer cards, as if a card is in a deck twice
+			# we also want to be able to predict the deck if we only observe it once.
+			for i in range(1, count + 1):
+				keys.add(self._get_card_key(card_id, i))
+		return keys
+
+	def _get_card_key(self, card_id: int, count: int = 1) -> str:
+		if not isinstance(card_id, int):
+			raise ValueError("Expected dbf id as card id")
+		return f"{self.namespace}:ILT:{int(card_id)}:x{int(count)}"
+
+	def _get_deck_key(self, deck_id: int) -> str:
+		return f"{self.namespace}:POPULARITY:{deck_id}"
+
+	def predict(self, dbf_map: Dict[int, int]) -> Optional[int]:
+		# check to see whether enough the deck to predict has enough cards
+		if not self._is_predictable_deck(dbf_map):
+			return None
+
+		# get the associated redis keys
+		keys = self._get_card_keys(dbf_map)
+
+		# check for expiry first
+		now_msecs = int(time.time() * 1000)
+		lookback_msecs = self.ilt_lookback_mins * 60 * 1000
+		pipeline = self.redis.pipeline()
+		for key in keys:
+			pipeline.zremrangebyscore(key, 0, now_msecs - lookback_msecs)
+		pipeline.execute()
+
+		# trivial case: find the decks from a intersection over all cards
+		candidates = self._zinter(keys)
+		if len(candidates):
+			deck_ids = map(lambda deck_id: int(deck_id.decode("utf-8")), candidates)
+			return max(deck_ids, key=lambda deck_id: self._get_popularity_for_deck(deck_id))
+
+		# count number of decks for each card once before fuzzy matching
+		sorted_keys = sorted(keys, key=lambda key: self.redis.zcard(key))
+		required_keys = self._get_card_keys({key: 1 for key in self.required_cards})
+
+		# fuzzy matching: as long as we can safely remove one card...
+		while len(sorted_keys) > self.min_cards_for_prediction:
+			# ...find a non-required card to remove
+			for index, key_to_remove in enumerate(sorted_keys):
+				if key_to_remove not in required_keys:
+					del sorted_keys[index]
+					break
+			else:
+				# we were unable to remove anything, terminate
+				return None
+			# ...calculate our new candidates
+			candidates = self._zinter(sorted_keys)
+			# ...and finally check whether we got a match
+			if len(candidates) > 0:
+				deck_ids = map(lambda deck_id: int(deck_id.decode("utf-8")), candidates)
+				return max(deck_ids, key=lambda deck_id: self._get_popularity_for_deck(deck_id))
+
+		# we were unable to match a deck
+		return None
+
+	def _zinter(self, keys: Iterable[str]) -> List[str]:
+		tmp_key = f"{self.namespace}:INTERSECT:{uuid4()}"
+		pipeline = self.redis.pipeline()
+		pipeline.zinterstore(tmp_key, keys=keys)
+		pipeline.zrange(tmp_key, 0, -1)
+		pipeline.delete(tmp_key)
+		results = pipeline.execute()
+		return results[1]
+
+	def _is_predictable_deck(self, dbf_map: Dict[int, int]) -> bool:
+		num_cards = 0
+		for card_id, count in dbf_map.items():
+			num_cards = num_cards + count
+			if num_cards >= self.min_cards_for_prediction:
+				# we've seen enough, terminate early
+				return True
+		else:
+			# if the loop exits normally we haven't seen enough cards
+			return False
+
+	def _get_popularity_for_deck(self, deck_id: int) -> int:
+		key = self._get_deck_key(deck_id)
+		now_msecs = int(time.time() * 1000)
+		lookback_msecs = self.deck_popularity_lookback_mins * 60 * 1000
+		# remove all observations with a "timestamp" (score) that is too old (low)
+		self.redis.zremrangebyscore(key, 0, now_msecs - lookback_msecs)
+		# count all remaining observations (0, -1 do not work here and we need -/+inf)
+		return self.redis.zcount(key, "-inf", "+inf")
+
+
+def inverse_lookup_table(
+	game_format: FormatType, player_class: CardClass, redis_client=None
+) -> BaseInverseLookupTable:
+	if not redis_client:
+		from django.core.cache import caches
+		redis_client = caches["ilt_deck_prediction"]
+
+	required_cards = ClusterSnapshot.objects.get_required_cards_for_player_class(
+		game_format, player_class
+	)
+
+	return RedisInverseLookupTable(redis_client, game_format, player_class, required_cards)

--- a/tests/test_deck_prediction.py
+++ b/tests/test_deck_prediction.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import fakeredis
+import pytest
 from hearthstone.enums import CardClass, FormatType
 
-from hsreplaynet.utils.prediction import DeckPredictionTree
+from hsreplaynet.utils.prediction import DeckPredictionTree, RedisInverseLookupTable
 
 
 DOOMSAYER = 138
@@ -85,3 +87,345 @@ def test_prediction_tree(_mock_lock):
 		UNOBSERVED_PLAY_SEQUENCE
 	).predicted_deck_id
 	assert lookup_result_5 is None
+
+
+@pytest.fixture(scope="function")
+def redis():
+	redis = fakeredis.FakeStrictRedis()
+	yield redis
+	redis.flushall()
+
+
+@pytest.fixture(scope="function")
+def mock_time(mocker):
+	"""This fixture mocks the current time to the provided datetime when called."""
+	def inner(ts: datetime) -> None:
+		mocker.patch("fakeredis.datetime", mocker.Mock(now=lambda: ts))
+		mocker.patch(
+			"hsreplaynet.utils.prediction.time",
+			mocker.Mock(time=lambda: ts.timestamp())
+		)
+	return inner
+
+
+def test_inverse_lookup_table_observes_complete_deck(redis):
+	ilt = RedisInverseLookupTable(redis, FormatType.FT_STANDARD, CardClass.DRUID)
+	ilt.observe({
+		1: 2,
+		2: 2,
+		3: 2,
+		4: 2,
+		5: 2,
+		6: 2,
+		7: 2,
+		8: 2,
+		9: 2,
+		10: 2,
+		11: 2,
+		12: 2,
+		13: 2,
+		14: 2,
+		15: 1,
+		16: 1,
+	}, 1)
+
+
+def test_inverse_lookup_table_does_not_observe_incomplete_deck(redis):
+	ilt = RedisInverseLookupTable(redis, FormatType.FT_STANDARD, CardClass.DRUID)
+	with pytest.raises(ValueError):
+		ilt.observe({
+			1: 2,
+			2: 2,
+			3: 2,
+			4: 2,
+			5: 2,
+			6: 2,
+			7: 2,
+			8: 2,
+			9: 2,
+			10: 2,
+			11: 2,
+			12: 2,
+			13: 2,
+			14: 2,
+			15: 1,
+		}, 1)
+
+
+def test_inverse_lookup_table_predicts_single_deck(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	# connect to Redis through a second ILT to ensure there is no local state inside the ILT
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) == 1
+
+
+def test_inverse_lookup_table_predicts_double_card_deck_with_single_card(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 2: 1, 3: 1}) == 1
+
+
+def test_inverse_lookup_table_predicts_more_popular_deck(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	ilt.observe({1: 1, 3: 2, 4: 1}, 2)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) == 1
+
+
+def test_inverse_lookup_table_predicts_fuzzy_deck(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 2: 1, 4: 1}) == 1
+
+
+def test_inverse_lookup_table_does_not_remove_required_card(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		required_cards={4},
+	)
+	assert remote_ilt.predict({1: 1, 2: 1, 4: 1}) is None
+
+
+def test_inverse_lookup_table_deck_popularities_expire(redis, mock_time):
+	# 8am: observe a bunch of decks with 1h expiry
+	mock_time(datetime(2019, 1, 1, 8, 0))
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4,
+		ilt_lookback_mins=240,
+		deck_popularity_lookback_mins=60,
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+
+	# 10am: observe a single deck
+	mock_time(datetime(2019, 1, 1, 10, 0))
+	ilt.observe({1: 1, 3: 2, 4: 1}, 2)
+
+	# ensure that we have forgotten about popularity from the decks from 2hrs ago
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		ilt_lookback_mins=240,
+		deck_popularity_lookback_mins=60,
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) == 2
+
+
+def test_inverse_lookup_table_deck_popularities_expire_in_sliding_window(redis, mock_time):
+	# 8am: observe deck #1 twice
+	mock_time(datetime(2019, 1, 1, 8, 0))
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4,
+		ilt_lookback_mins=240,
+		deck_popularity_lookback_mins=90,
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+
+	# 9am: refresh deck #1
+	mock_time(datetime(2019, 1, 1, 9, 0))
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+
+	# 10am: ensure that deck #1 has only 1 observation remaining and deck #2 is picked
+	mock_time(datetime(2019, 1, 1, 10, 0))
+	ilt.observe({1: 1, 3: 2, 4: 1}, 2)
+	ilt.observe({1: 1, 3: 2, 4: 1}, 2)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		ilt_lookback_mins=240,
+		deck_popularity_lookback_mins=90,
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) == 2
+
+
+def test_inverse_lookup_table_ilts_expire(redis, mock_time):
+	# 8am: Observe a deck with 1h expiry
+	mock_time(datetime(2019, 1, 1, 8, 0))
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4,
+		ilt_lookback_mins=60,
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+
+	# 10am: Ensure we have forgotten about the deck
+	mock_time(datetime(2019, 1, 1, 10, 0))
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		ilt_lookback_mins=60,
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) is None
+
+
+def test_inverse_lookup_table_ilts_expire_in_sliding_window(redis, mock_time):
+	# 8am: Observe a deck with 90m expiry twice
+	mock_time(datetime(2019, 1, 1, 8, 0))
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4,
+		ilt_lookback_mins=90,
+		deck_popularity_lookback_mins=240,
+	)
+	# Let's observe this deck twice and keep the popularity lookback very high.
+	# This ensures that if the ILTs erroneously reference this deck, it will be the result
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+
+	# 9am: Observe a similar deck to refresh the card keys' timestamp
+	mock_time(datetime(2019, 1, 1, 9))
+	ilt.observe({1: 1, 3: 2, 4: 1}, 2)
+
+	# 10am: Ensure we don't have any reference to the old deck
+	mock_time(datetime(2019, 1, 1, 10))
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		ilt_lookback_mins=90,
+		deck_popularity_lookback_mins=240,
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) == 2
+
+
+def test_inverse_lookup_table_does_not_predict_unknown_deck(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1,
+		full_deck_size=4
+	)
+	ilt.observe({4: 2, 5: 1, 6: 1}, 1)
+	assert ilt.predict({1: 1, 2: 1, 3: 2}) is None
+
+
+def test_inverse_lookup_table_does_not_predict_too_few_cards(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		min_cards_for_prediction=3,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	assert ilt.predict({1: 1}) is None
+
+
+def test_inverse_lookup_table_isolates_game_format(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_WILD,
+		CardClass.DRUID,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) is None
+
+
+def test_inverse_lookup_table_isolates_player_class(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+	ilt.observe({1: 1, 2: 1, 3: 2}, 1)
+	remote_ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.SHAMAN,
+		min_cards_for_prediction=1
+	)
+	assert remote_ilt.predict({1: 1, 3: 2}) is None
+
+
+def test_inverse_lookup_table_observe_enforces_dbf_ids(redis):
+	ilt = RedisInverseLookupTable(
+		redis,
+		FormatType.FT_STANDARD,
+		CardClass.DRUID,
+		full_deck_size=4
+	)
+
+	with pytest.raises(ValueError):
+		ilt.observe({"GVG_006": 2, "GVG_037": 2}, 1)


### PR DESCRIPTION
This PR contains the initial version of the new ILT-based deck prediction. It still needs:
- [x] GameType namespacing
- [x] CardClass namespacing
- [x] processing integration (including metrics)