### PR TITLE
1033/filter-replays-by-current-season

### DIFF
--- a/hsreplaynet/static/scripts/src/GameFilters.ts
+++ b/hsreplaynet/static/scripts/src/GameFilters.ts
@@ -2,6 +2,7 @@ import { GameReplay, GlobalGamePlayer } from "./interfaces";
 import { BnetGameType, FormatType } from "./hearthstone";
 import { getHeroCard } from "./helpers";
 import CardData from "./CardData";
+import { isSameMonth, subMonths } from "date-fns";
 
 export function nameMatch(game: GameReplay, name: string): boolean {
 	const players = [game.friendly_player, game.opposing_player];
@@ -80,8 +81,17 @@ export function resultMatch(game: GameReplay, result: string): boolean {
 }
 
 export function seasonMatch(game: GameReplay, season: string): boolean {
-	if (game.global_game.ladder_season === parseInt(season, 10)) {
-		return true;
+	const currentSeasonDate = Date.now();
+	switch (season) {
+		case "current":
+			return isSameMonth(game.global_game.match_start, currentSeasonDate);
+		case "previous":
+			return isSameMonth(
+				game.global_game.match_start,
+				subMonths(currentSeasonDate, 1),
+			);
+		default:
+			return true;
 	}
 
 	return false;

--- a/hsreplaynet/static/scripts/src/GameFilters.ts
+++ b/hsreplaynet/static/scripts/src/GameFilters.ts
@@ -79,6 +79,14 @@ export function resultMatch(game: GameReplay, result: string): boolean {
 	}
 }
 
+export function seasonMatch(game: GameReplay, season: string): boolean {
+	if (game.global_game.ladder_season === parseInt(season, 10)) {
+		return true;
+	}
+
+	return false;
+}
+
 export function heroMatch(
 	cardData: CardData,
 	player: GlobalGamePlayer,

--- a/hsreplaynet/static/scripts/src/__tests__/GameFilters.spec.ts
+++ b/hsreplaynet/static/scripts/src/__tests__/GameFilters.spec.ts
@@ -11,12 +11,13 @@ import * as TypeMoq from "typemoq";
 import { BnetGameType, FormatType } from "../hearthstone";
 import CardData from "../CardData";
 import { CardData as HearthstoneJSONCardData } from "hearthstonejson-client";
+import { subMonths } from "date-fns";
 
 describe("nameMatch", () => {
-	const createReplay = function(
+	const createReplay = (
 		player1Name: string,
 		player2Name?: string,
-	): GameReplay {
+	): GameReplay => {
 		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
 			GameReplay
 		>();
@@ -65,7 +66,7 @@ describe("nameMatch", () => {
 });
 
 describe("modeMatch", () => {
-	const createReplay = function(gameType: BnetGameType): GameReplay {
+	const createReplay = (gameType: BnetGameType): GameReplay => {
 		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
 			GameReplay
 		>();
@@ -135,7 +136,7 @@ describe("modeMatch", () => {
 });
 
 describe("formatMatch", () => {
-	const createReplay = function(format: FormatType): GameReplay {
+	const createReplay = (format: FormatType): GameReplay => {
 		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
 			GameReplay
 		>();
@@ -179,7 +180,7 @@ describe("formatMatch", () => {
 });
 
 describe("resultMatch", () => {
-	const createReplay = function(won: boolean): GameReplay {
+	const createReplay = (won: boolean): GameReplay => {
 		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
 			GameReplay
 		>();
@@ -204,7 +205,7 @@ describe("resultMatch", () => {
 });
 
 describe("seasonMatch", () => {
-	const createReplay = function(season: number): GameReplay {
+	const createReplay = (seasonDate: Date): GameReplay => {
 		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
 			GameReplay
 		>();
@@ -212,7 +213,9 @@ describe("seasonMatch", () => {
 			GlobalGame
 		>();
 
-		mockedGlobalGame.setup(x => x.ladder_season).returns(() => season);
+		mockedGlobalGame
+			.setup(x => x.match_start)
+			.returns(() => seasonDate.toDateString());
 		mockedGameReplay
 			.setup(x => x.global_game)
 			.returns(() => mockedGlobalGame.object);
@@ -220,14 +223,25 @@ describe("seasonMatch", () => {
 		return mockedGameReplay.object;
 	};
 
-	const season1Game: GameReplay = createReplay(1);
+	const currentSeasonGame: GameReplay = createReplay(new Date());
+	const previousSeasonGame: GameReplay = createReplay(
+		subMonths(new Date(), 1),
+	);
 
-	test("correctly matches the game result", () => {
-		expect(seasonMatch(season1Game, "1")).toBe(true);
+	test("correctly matches the current season game result", () => {
+		expect(seasonMatch(currentSeasonGame, "current")).toBe(true);
 	});
 
-	test("does not match the game result", () => {
-		expect(seasonMatch(season1Game, "2")).toBe(false);
+	test("does not match the current season game result", () => {
+		expect(seasonMatch(currentSeasonGame, "previous")).toBe(false);
+	});
+
+	test("correctly matches the previous season game result", () => {
+		expect(seasonMatch(previousSeasonGame, "current")).toBe(false);
+	});
+
+	test("does not match the previous season game result", () => {
+		expect(seasonMatch(previousSeasonGame, "previous")).toBe(true);
 	});
 });
 

--- a/hsreplaynet/static/scripts/src/__tests__/GameFilters.spec.ts
+++ b/hsreplaynet/static/scripts/src/__tests__/GameFilters.spec.ts
@@ -4,6 +4,7 @@ import {
 	modeMatch,
 	nameMatch,
 	resultMatch,
+	seasonMatch,
 } from "../GameFilters";
 import { GameReplay, GlobalGame, GlobalGamePlayer } from "../interfaces";
 import * as TypeMoq from "typemoq";
@@ -199,6 +200,34 @@ describe("resultMatch", () => {
 	test("returns true for unrecognized results", () => {
 		expect(resultMatch(winningGame, "called_it_even")).toBe(true);
 		expect(resultMatch(losingGame, "its_a_toss_up")).toBe(true);
+	});
+});
+
+describe("seasonMatch", () => {
+	const createReplay = function(season: number): GameReplay {
+		const mockedGameReplay: TypeMoq.IMock<GameReplay> = TypeMoq.Mock.ofType<
+			GameReplay
+		>();
+		const mockedGlobalGame: TypeMoq.IMock<GlobalGame> = TypeMoq.Mock.ofType<
+			GlobalGame
+		>();
+
+		mockedGlobalGame.setup(x => x.ladder_season).returns(() => season);
+		mockedGameReplay
+			.setup(x => x.global_game)
+			.returns(() => mockedGlobalGame.object);
+
+		return mockedGameReplay.object;
+	};
+
+	const season1Game: GameReplay = createReplay(1);
+
+	test("correctly matches the game result", () => {
+		expect(seasonMatch(season1Game, "1")).toBe(true);
+	});
+
+	test("does not match the game result", () => {
+		expect(seasonMatch(season1Game, "2")).toBe(false);
 	});
 });
 

--- a/hsreplaynet/static/scripts/src/entries/my_replays.tsx
+++ b/hsreplaynet/static/scripts/src/entries/my_replays.tsx
@@ -34,6 +34,7 @@ const render = (cardData: CardData) => {
 					mode: "",
 					format: "",
 					result: "",
+					season: "",
 					hero: "ALL",
 					opponent: "ALL",
 				}}

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -74,8 +74,6 @@ interface State {
 
 class MyReplays extends React.Component<Props, State> {
 	readonly viewCookie: string = "myreplays_viewtype";
-	// javascript december is 11 not 12
-	readonly firstRankedSeason: Date = new Date(2013, 11);
 
 	constructor(props: Props, context?: any) {
 		super(props, context);
@@ -297,7 +295,6 @@ class MyReplays extends React.Component<Props, State> {
 
 		let page = 0;
 		const firstPage = this.state.gamesPages[page];
-
 		if (firstPage) {
 			games = this.filterGames(firstPage);
 			// we load one more than we need so we know whether there is next page
@@ -307,6 +304,14 @@ class MyReplays extends React.Component<Props, State> {
 			) {
 				const nextPage = this.state.gamesPages[++page];
 				if (!nextPage) {
+					if (
+						this.props.season &&
+						nextPage.some(
+							game => !seasonMatch(game, this.props.season),
+						)
+					) {
+						break;
+					}
 					if (
 						this.state.next &&
 						!this.state.working &&

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -297,31 +297,40 @@ class MyReplays extends React.Component<Props, State> {
 		const firstPage = this.state.gamesPages[page];
 		if (firstPage) {
 			games = this.filterGames(firstPage);
-			// we load one more than we need so we know whether there is next page
-			while (
-				games.length <
-				this.state.pageSize * (this.state.currentLocalPage + 1) + 1
+			if (
+				!this.props.season ||
+				firstPage.every(
+					game => seasonMatch(game, this.props.season),
+				)
 			) {
-				const nextPage = this.state.gamesPages[++page];
-				if (!nextPage) {
+				// we load one more than we need so we know whether there is next page
+				while (
+					games.length <
+					this.state.pageSize * (this.state.currentLocalPage + 1) + 1
+					) {
+					const nextPage = this.state.gamesPages[++page];
 					if (
+						nextPage &&
 						this.props.season &&
 						nextPage.some(
 							game => !seasonMatch(game, this.props.season),
 						)
 					) {
+						games = games.concat(this.filterGames(nextPage));
 						break;
 					}
-					if (
-						this.state.next &&
-						!this.state.working &&
-						(hasFilters || page === this.state.currentLocalPage)
-					) {
-						this.query(this.state.next);
+					if (!nextPage) {
+						if (
+							this.state.next &&
+							!this.state.working &&
+							(hasFilters || page === this.state.currentLocalPage)
+						) {
+							this.query(this.state.next);
+						}
+						break;
 					}
-					break;
+					games = games.concat(this.filterGames(nextPage));
 				}
-				games = games.concat(this.filterGames(nextPage));
 			}
 			// slice off everything before the currentLocalPage
 			games = games.slice(

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -29,7 +29,6 @@ import {
 } from "../interfaces";
 import Sticky from "../components/utils/Sticky";
 import NetworkNAdUnit from "../components/ads/NetworkNAdUnit";
-import { differenceInCalendarMonths } from "date-fns";
 
 type ViewType = "tiles" | "list";
 
@@ -71,7 +70,6 @@ interface State {
 	showFilters: boolean;
 	viewType: ViewType;
 	working: boolean;
-	currentSeason: string;
 }
 
 class MyReplays extends React.Component<Props, State> {
@@ -92,10 +90,6 @@ class MyReplays extends React.Component<Props, State> {
 			showFilters: false,
 			viewType,
 			working: true,
-			currentSeason: differenceInCalendarMonths(
-				Date.now(),
-				this.firstRankedSeason,
-			).toString(),
 		};
 	}
 
@@ -542,8 +536,11 @@ class MyReplays extends React.Component<Props, State> {
 						selectedValue={this.props.season}
 						onClick={season => this.props.setSeason(season)}
 					>
-						<InfoboxFilter value={this.state.currentSeason}>
+						<InfoboxFilter value={"current"}>
 							{t("Current season")}
+						</InfoboxFilter>
+						<InfoboxFilter value={"previous"}>
+							{t("Previous season")}
 						</InfoboxFilter>
 					</InfoboxFilterGroup>
 					{backButton}

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -18,6 +18,7 @@ import {
 	modeMatch,
 	nameMatch,
 	resultMatch,
+	seasonMatch,
 } from "../GameFilters";
 import { getHeroCard, image } from "../helpers";
 import {
@@ -28,6 +29,7 @@ import {
 } from "../interfaces";
 import Sticky from "../components/utils/Sticky";
 import NetworkNAdUnit from "../components/ads/NetworkNAdUnit";
+import { differenceInCalendarMonths } from "date-fns";
 
 type ViewType = "tiles" | "list";
 
@@ -55,6 +57,8 @@ interface Props
 	setHero?: (hero: string) => void;
 	opponent?: string;
 	setOpponent?: (opponent: string) => void;
+	season?: string;
+	setSeason?: (result: string) => void;
 }
 
 interface State {
@@ -67,10 +71,13 @@ interface State {
 	showFilters: boolean;
 	viewType: ViewType;
 	working: boolean;
+	currentSeason: string;
 }
 
 class MyReplays extends React.Component<Props, State> {
 	readonly viewCookie: string = "myreplays_viewtype";
+	// javascript december is 11 not 12
+	readonly firstRankedSeason: Date = new Date(2013, 11);
 
 	constructor(props: Props, context?: any) {
 		super(props, context);
@@ -85,6 +92,10 @@ class MyReplays extends React.Component<Props, State> {
 			showFilters: false,
 			viewType,
 			working: true,
+			currentSeason: differenceInCalendarMonths(
+				Date.now(),
+				this.firstRankedSeason,
+			).toString(),
 		};
 	}
 
@@ -154,6 +165,7 @@ class MyReplays extends React.Component<Props, State> {
 		const mode = this.props.mode;
 		const format = this.props.format;
 		const result = this.props.result;
+		const season = this.props.season;
 		const hero = this.props.hero !== "ALL" ? this.props.hero : null;
 		const opponent =
 			this.props.opponent !== "ALL" ? this.props.opponent : null;
@@ -169,6 +181,9 @@ class MyReplays extends React.Component<Props, State> {
 					return false;
 				}
 				if (result && !resultMatch(game, result)) {
+					return false;
+				}
+				if (season && !seasonMatch(game, season)) {
 					return false;
 				}
 				if (
@@ -520,6 +535,16 @@ class MyReplays extends React.Component<Props, State> {
 					>
 						<InfoboxFilter value="won">{t("Won")}</InfoboxFilter>
 						<InfoboxFilter value="lost">{t("Lost")}</InfoboxFilter>
+					</InfoboxFilterGroup>
+					<h2>{t("Season")}</h2>
+					<InfoboxFilterGroup
+						deselectable
+						selectedValue={this.props.season}
+						onClick={season => this.props.setSeason(season)}
+					>
+						<InfoboxFilter value={this.state.currentSeason}>
+							{t("Current season")}
+						</InfoboxFilter>
 					</InfoboxFilterGroup>
 					{backButton}
 					<Sticky bottom={0} key="ads">

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -406,7 +406,7 @@ class MyReplays extends React.Component<Props, State> {
 			</button>
 		);
 
-		const pager = (
+		const pager = games.length >= this.state.pageSize || this.state.currentLocalPage > 0 ? (
 			<Pager
 				currentPage={this.state.currentLocalPage + 1}
 				setCurrentPage={(p: number) =>
@@ -419,7 +419,7 @@ class MyReplays extends React.Component<Props, State> {
 				}
 				minimal
 			/>
-		);
+		) : null;
 
 		return (
 			<div className="my-replays-content">

--- a/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
+++ b/hsreplaynet/static/scripts/src/pages/MyReplays.tsx
@@ -299,15 +299,13 @@ class MyReplays extends React.Component<Props, State> {
 			games = this.filterGames(firstPage);
 			if (
 				!this.props.season ||
-				firstPage.every(
-					game => seasonMatch(game, this.props.season),
-				)
+				firstPage.every(game => seasonMatch(game, this.props.season))
 			) {
 				// we load one more than we need so we know whether there is next page
 				while (
 					games.length <
 					this.state.pageSize * (this.state.currentLocalPage + 1) + 1
-					) {
+				) {
 					const nextPage = this.state.gamesPages[++page];
 					if (
 						nextPage &&
@@ -406,20 +404,22 @@ class MyReplays extends React.Component<Props, State> {
 			</button>
 		);
 
-		const pager = games.length >= this.state.pageSize || this.state.currentLocalPage > 0 ? (
-			<Pager
-				currentPage={this.state.currentLocalPage + 1}
-				setCurrentPage={(p: number) =>
-					this.setState({ currentLocalPage: p - 1 })
-				}
-				pageCount={
-					this.state.next
-						? null
-						: Object.keys(this.state.gamesPages).length
-				}
-				minimal
-			/>
-		) : null;
+		const pager =
+			games.length >= this.state.pageSize ||
+			this.state.currentLocalPage > 0 ? (
+				<Pager
+					currentPage={this.state.currentLocalPage + 1}
+					setCurrentPage={(p: number) =>
+						this.setState({ currentLocalPage: p - 1 })
+					}
+					pageCount={
+						this.state.next
+							? null
+							: Object.keys(this.state.gamesPages).length
+					}
+					minimal
+				/>
+			) : null;
 
 		return (
 			<div className="my-replays-content">


### PR DESCRIPTION
added new filter for current season, tests for new game filter function, and new query param for season date. as implemented when `Current season` option is clicked will return current season, though in future could be extended to allow users to filter on any season. is currently possible to filter on any season if user manually manipulates the query param to be a previous season number